### PR TITLE
GH actions - Bump micromamba version to v3

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -62,7 +62,7 @@ jobs:
         if: runner.os == 'Linux'
         env:
           CC: gcc-${{ env.GCC_VERSION }}
-        uses: mamba-org/setup-micromamba@v2
+        uses: mamba-org/setup-micromamba@v3
         with:
           environment-file: ${{ env.LINUX_YAML }}
           init-shell: bash
@@ -73,7 +73,7 @@ jobs:
         if: runner.os == 'macOS'
         env:
           CONDA_SUBDIR: osx-64
-        uses: mamba-org/setup-micromamba@v2
+        uses: mamba-org/setup-micromamba@v3
         with:
           environment-file: ${{ env.MACOS_YAML }}
           init-shell: bash


### PR DESCRIPTION
Addresses the following warning when running actions:
```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: mamba-org/setup-micromamba@v2. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```