### PR TITLE
Combine methods to calcualte `sati` and `satw`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,20 +8,43 @@ IndentWidth: 4
 UseTab: Never
 MaxEmptyLinesToKeep: 1
 
-ReflowComments: True
+# Line Wrapping & Breaking
+ReflowComments: true # Wraps long comment lines to fit ColumnLimit
+BreakBeforeBraces: Attach # Keeps opening braces on the same line as statements
+BreakBeforeBinaryOperators: All # Wraps lines BEFORE operators (e.g., +, &&)
+AlignAfterOpenBracket: BlockIndent # Aligns wrapped arguments to a new indented block
 
-BreakBeforeBraces: Attach
-BreakBeforeBinaryOperators: All
-AlignAfterOpenBracket: BlockIndent
-BinPackArguments: false
-BinPackParameters: false
-AlignEscapedNewlines: Left
-IndentCaseLabels: true
-
+# Parameter & Argument Layout
+BinPackArguments: false # Forces one argument per line if they wrap
+BinPackParameters: false # Forces one parameter per line if they wrap
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowAllArgumentsOnNextLine: true
 
-AlignConsecutiveMacros:
+# Alignment Rules
+IndentCaseLabels: true # Indents 'case' statements inside a 'switch'
+AlignEscapedNewlines: Left # Aligns backslashes in multi-line macros to the left
+
+AlignConsecutiveMacros: # Aligns macro definitions horizontally
     Enabled: true
     AcrossEmptyLines: true
     AcrossComments: false
+
+AlignConsecutiveAssignments: # Aligns '=' operators on consecutive lines
+    Enabled: true
+    AcrossEmptyLines: false
+    AcrossComments: true
+
+# Code Style & Readability
+PointerAlignment: Right # Places asterisk next to name: 'int *ptr'
+SortIncludes: CaseSensitive # Automatically sorts #include headers alphabetically
+
+# Whitespace Padding
+SpaceBeforeParens: Custom # Required to unlock fine-grained spacing rules
+SpaceBeforeParensOptions: # Replaces the deprecated SpaceBeforeFunctionDeclarationParens flag
+    AfterFunctionDeclarationName: false # Enforces 'void func()' instead of 'void func ()'
+    AfterFunctionDefinitionName: false # Enforces 'void func() {}' instead of 'void func () {}'
+    AfterControlStatements: true # Enforces 'if (x)' instead of 'if(x)'
+SpacesInParens: Custom # Replaces deprecated 'SpaceInEmptyParentheses'
+SpacesInParensOptions:
+    InEmptyParentheses: false # Disallows spaces like 'void func( )
+SpacesInContainerLiterals: true # Adds spacing inside initializers: '{ 1, 2 }'

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,27 @@
+BasedOnStyle: LLVM
+Language: C
+
+# Core Formatting
+ColumnLimit: 100
+TabWidth: 4
+IndentWidth: 4
+UseTab: Never
+MaxEmptyLinesToKeep: 1
+
+ReflowComments: True
+
+BreakBeforeBraces: Attach
+BreakBeforeBinaryOperators: All
+AlignAfterOpenBracket: BlockIndent
+BinPackArguments: false
+BinPackParameters: false
+AlignEscapedNewlines: Left
+IndentCaseLabels: true
+
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowAllArgumentsOnNextLine: true
+
+AlignConsecutiveMacros:
+    Enabled: true
+    AcrossEmptyLines: true
+    AcrossComments: false

--- a/smrf/data/input/wrf.py
+++ b/smrf/data/input/wrf.py
@@ -5,7 +5,7 @@ import pytz
 
 from smrf.data.input.gridded_input import GriddedInput
 from smrf.data.input.netcdf import metadata_name_from_index
-from smrf.envphys.vapor_pressure import satvp
+from smrf.envphys.vapor_pressure import svp_for_celsius
 from smrf.utils.utils import apply_utm
 
 
@@ -143,9 +143,8 @@ class InputWRF(GriddedInput):
         self.air_temp = self.air_temp - 273.15
 
         self._logger.debug('Calculating vapor_pressure')
-        vp = satvp(self.dew_point.values)
-        self.vapor_pressure = pd.DataFrame(
-            vp, index=time, columns=self.primary_id)
+        vp = svp_for_celsius(self.dew_point.values)
+        self.vapor_pressure = pd.DataFrame(vp, index=time, columns=self.primary_id)
 
         self._logger.debug('Loading cloud_factor')
         self.cloud_factor = pd.DataFrame(index=time, columns=self.primary_id)

--- a/smrf/distribute/vapor_pressure.py
+++ b/smrf/distribute/vapor_pressure.py
@@ -1,9 +1,9 @@
-
 import numpy as np
 
-from .variable_base import VariableBase
 from smrf.envphys.core import envphys_c
 from smrf.utils import utils
+
+from .variable_base import VariableBase
 
 
 class VaporPressure(VariableBase):
@@ -13,8 +13,8 @@ class VaporPressure(VariableBase):
     :mod:`smrf.envphys.vapor_pressure.rh2vp`. The vapor pressure is distributed
     instead of the relative humidity as it is an absolute measurement of the
     vapor within the atmosphere and will follow elevational trends (typically
-    negative).  Were as relative humidity is a relative measurement which
-    varies in complex ways over the topography.  From the distributed vapor
+    negative). Wereas relative humidity is a relative measurement which
+    varies in complex ways over the topography. From the distributed vapor
     pressure, the dew point is calculated for use by other distribution
     methods. The dew point temperature is further corrected to ensure that it
     does not exceed the distributed air temperature.
@@ -49,7 +49,7 @@ class VaporPressure(VariableBase):
     def distribute(self, data, ta):
         """
         Distribute air temperature given a Panda's dataframe for a single time
-        step. Calls :mod:`smrf.distribute.ImageData._distribute`.
+        step. Calls :mod:`smrf.distribute.VariableBase._distribute`.
 
         The following steps are performed when distributing vapor pressure:
 
@@ -65,18 +65,16 @@ class VaporPressure(VariableBase):
 
         """
 
-        self._logger.debug('%s -- Distributing vapor_pressure' % data.name)
+        self._logger.debug("%s -- Distributing vapor_pressure" % data.name)
 
         # calculate the vapor pressure
         self._distribute(data)
 
         # set the limits
-        self.vapor_pressure = utils.set_min_max(self.vapor_pressure,
-                                                self.min,
-                                                self.max)
+        self.vapor_pressure = utils.set_min_max(self.vapor_pressure, self.min, self.max)
 
         # calculate the dew point
-        self._logger.debug('%s -- Calculating dew point' % data.name)
+        self._logger.debug("%s -- Calculating dew point" % data.name)
 
         # use the core_c to calculate the dew point
         dew_point_temperature = np.zeros_like(self.vapor_pressure, dtype=np.float64)
@@ -89,13 +87,13 @@ class VaporPressure(VariableBase):
 
         ind = dew_point_temperature >= ta
 
-        if (np.sum(ind) > 0):
+        if np.sum(ind) > 0:
             dew_point_temperature[ind] = ta[ind] - 0.2
 
         self.dew_point = dew_point_temperature
 
         # calculate wet bulb temperature
-        if self.precip_temp_method == 'wet_bulb':
+        if self.precip_temp_method == "wet_bulb":
             # initialize timestep wet_bulb
             wet_bulb = np.zeros_like(self.vapor_pressure, dtype=np.float64)
             # calculate wet_bulb

--- a/smrf/envphys/core/dewpt.c
+++ b/smrf/envphys/core/dewpt.c
@@ -1,7 +1,3 @@
-/*
- * Saturation function over ice and water
- */
-
 #include <stdio.h>
 #include <math.h>
 #include <errno.h>

--- a/smrf/envphys/core/dewpt.c
+++ b/smrf/envphys/core/dewpt.c
@@ -1,9 +1,11 @@
-#include <stdio.h>
-#include <math.h>
-#include <errno.h>
-#include <omp.h>
 #include "envphys.h"
 #include "envphys_c.h"
+#include <errno.h>
+#include <float.h>
+#include <math.h>
+#include <omp.h>
+#include <stdio.h>
+#include <tgmath.h>
 
 extern int errno;
 
@@ -121,10 +123,10 @@ zerobr(
 		return(a);
 	}
 
-	fb = (ABS(b) >= ABS(a)) ? ABS(b) : ABS(a);
-	tol = 5.e-1 * t + 2 * meps * fb;
-	s = log(ABS(b - a) / tol) / log(2.);
-	maxfun = s * s + 1;
+    fb     = (fabs(b) >= fabs(a)) ? fabs(b) : fabs(a);
+    tol    = 5.e-1 * t + 2 * meps * fb;
+    s      = log(fabs(b - a) / tol) / log(2.);
+    maxfun = s * s + 1;
 
 	fa = satm(a);
 	fc = fb = satm(b);
@@ -132,10 +134,10 @@ zerobr(
 		return(0.);
 	}
 
-	if (ABS(fb) <= tol)
-		return(b);
-	if (ABS(fa) <= tol)
-		return(a);
+    if (fabs(fb) <= tol)
+        return (b);
+    if (fabs(fa) <= tol)
+        return (a);
 
 	if (fb*fa > 0) {
 		perror("zerobr: root not spanned");
@@ -153,24 +155,24 @@ zerobr(
 			d = e = b - a;
 		}
 
-		if (ABS(fc) < ABS(fb)) {
-			a = b;
-			b = c;
-			c = a;
-			fa = fb;
-			fb = fc;
-			fc = fa;
-		}
+        if (fabs(fc) < fabs(fb)) {
+            a  = b;
+            b  = c;
+            c  = a;
+            fa = fb;
+            fb = fc;
+            fc = fa;
+        }
 
-		tol = meps * ABS(b) + t;
-		m = (c - b) / 2;
+        tol = meps * fabs(b) + t;
+        m   = (c - b) / 2;
 
-		if (ABS(m) < tol  ||  fb == 0)
-			return(b);
+        if (fabs(m) < tol || fb == 0)
+            return (b);
 
-		/* see if bisection is forced */
-		if (ABS(e) < tol  ||  ABS(fa) <= ABS(fb))
-			d = e = m;
+        /* see if bisection is forced */
+        if (fabs(e) < tol || fabs(fa) <= fabs(fb))
+            d = e = m;
 
 		else {
 			s = fb/fa;
@@ -196,21 +198,21 @@ zerobr(
 			s = e;
 			e = d;
 
-			if (2*p < 3*m*q - ABS(tol*q) && p < ABS(s*q/2))
-				d = p/q;
-			else
-				d = e = m;
-		}
+            if (2 * p < 3 * m * q - fabs(tol * q) && p < fabs(s * q / 2))
+                d = p / q;
+            else
+                d = e = m;
+        }
 
 		a = b;
 		fa = fb;
 
-		if (ABS(d) > tol)
-			b += d;
-		else if (m > 0)
-			b += tol;
-		else
-			b -= tol;
+        if (fabs(d) > tol)
+            b += d;
+        else if (m > 0)
+            b += tol;
+        else
+            b -= tol;
 
 		fb = satm(b);
 		if (errno) {

--- a/smrf/envphys/core/dewpt.c
+++ b/smrf/envphys/core/dewpt.c
@@ -52,7 +52,7 @@ static double e_pass;
 static double
 satm(double t)
 {
-	return(e_pass - sati(t));
+	return(e_pass - saturation_vapor_pressure(&t));
 }
 
 /* ------------------------------------------------------------------------ */
@@ -74,12 +74,12 @@ dew_pointp(
 
 	/* lower */
 	a = FREEZE;
-	while (e < sati(a))
+	while (e < saturation_vapor_pressure(&a))
 		a *= .75;
 
 	/* upper */
 	b = FREEZE + 15;
-	while (e > sati(b))
+	while (e > saturation_vapor_pressure(&b))
 		b *= 1.25;
 
 	e_pass = e;

--- a/smrf/envphys/core/dewpt.c
+++ b/smrf/envphys/core/dewpt.c
@@ -10,40 +10,37 @@
 extern int errno;
 
 void dewpt(
-		int ngrid,		/* number of grid points */
-		double *ea,		/* vapor pressure */
-		int nthreads,	/* number of threads for parrallel processing */
-		double tol,		/* dew_point tolerance threshold */
-		double *dpt		/* dew point temp (return) */
-)
-{
-	int samp;
-	double ea_p; // pixel values
-	float dpt_p; // pixel value
+    int ngrid,    /* number of grid points */
+    double *ea,   /* vapor pressure */
+    int nthreads, /* number of threads for parrallel processing */
+    double tol,   /* dew_point tolerance threshold */
+    double *dpt   /* dew point temp (return) */
+) {
+    int samp;
+    double ea_p; // pixel values
+    float dpt_p; // pixel value
 
-	omp_set_dynamic(0);     // Explicitly disable dynamic teams
-	omp_set_num_threads(nthreads); // Use N threads for all consecutive parallel regions
+    omp_set_dynamic(0);            // Explicitly disable dynamic teams
+    omp_set_num_threads(nthreads); // Use N threads for all consecutive parallel regions
 
 #pragma omp parallel shared(ngrid, ea) private(samp, ea_p, dpt_p)
-	{
+    {
 #pragma omp for
 
-		for (samp=0; samp < ngrid; samp++) {
+        for (samp = 0; samp < ngrid; samp++) {
 
-			ea_p = ea[samp];
+            ea_p = ea[samp];
 
-			dpt_p = (float) dew_pointp((double) ea_p, tol);
+            dpt_p = (float)dew_pointp((double)ea_p, tol);
 
-			/*	convert from K to C	*/
-			dpt_p -= FREEZE;
+            /*	convert from K to C	*/
+            dpt_p -= FREEZE;
 
-			/* set output band */
+            /* set output band */
 
-			dpt[samp] = dpt_p;
-
-		}
-	}
-
+            dpt[samp] = dpt_p;
+        }
+    }
 }
 
 /* ------------------------------------------------------------------------ */
@@ -51,109 +48,101 @@ void dewpt(
 static double e_pass;
 #pragma omp threadprivate(e_pass)
 
-static double
-satm(double t)
+static double satm(double t) { return (e_pass - saturation_vapor_pressure(&t)); }
+
+/* ------------------------------------------------------------------------ */
+
+double dew_pointp(
+    double e, /* vapor pressure (Pa) */
+    double tol
+) /* tolerance threshold */
 {
-	return(e_pass - saturation_vapor_pressure(&t));
+    double a;
+    double b;
+    double result;
+
+    if (e < 0 || e > 1.5 * SEA_LEVEL) {
+        perror("dew_point: vapor pressure < 0 or 1.5*SEA_LEVEL");
+    }
+
+    /* select starting guesses to span root */
+
+    /* lower */
+    a = FREEZE;
+    while (e < saturation_vapor_pressure(&a))
+        a *= .75;
+
+    /* upper */
+    b = FREEZE + 15;
+    while (e > saturation_vapor_pressure(&b))
+        b *= 1.25;
+
+    e_pass = e;
+    result = zerobr(a, b, tol);
+
+    return (result);
 }
 
 /* ------------------------------------------------------------------------ */
 
-double
-dew_pointp(
-		double e, 	/* vapor pressure (Pa) */
-		double tol)	/* tolerance threshold */
+double zerobr(
+    double a, /* spanning guess for root	*/
+    double b, /* spanning guess for root	*/
+    double t
+) /* tolerable relative error	*/
 {
-	double	a;
-	double	b;
-	double	result;
+    double c = 0.;
+    double d = 0.;
+    double e = 0.;
+    double fa;
+    double fb;
+    double fc;
+    double m;
+    double p;
+    double q;
+    double r;
+    double s;
+    double tol;
+    double meps;
+    int maxfun;
 
-	if (e < 0 || e > 1.5*SEA_LEVEL) {
-		perror("dew_point: vapor pressure < 0 or 1.5*SEA_LEVEL");
-	}
+    meps  = DBL_EPSILON;
+    errno = 0;
 
-	/* select starting guesses to span root */
-
-	/* lower */
-	a = FREEZE;
-	while (e < saturation_vapor_pressure(&a))
-		a *= .75;
-
-	/* upper */
-	b = FREEZE + 15;
-	while (e > saturation_vapor_pressure(&b))
-		b *= 1.25;
-
-	e_pass = e;
-	result = zerobr(a, b, tol);
-
-	return(result);
-}
-
-/* ------------------------------------------------------------------------ */
-
-double
-zerobr(
-	double	a,		/* spanning guess for root	*/
-	double	b,		/* spanning guess for root	*/
-	double	t)		/* tolerable relative error	*/
-{
-	double	c =0.;
-	double	d =0.;
-	double	e =0.;
-	double	fa;
-	double	fb;
-	double	fc;
-	double	m;
-	double	p;
-	double	q;
-	double	r;
-	double	s;
-	double	tol;
-	double	meps;
-	int	maxfun;
-
-	meps = DBL_EPSILON;
-	errno = 0;
-
-	/* compute max number of function evaluations */
-	if (a == b) {
-		perror("zerobr: a = b");
-//		errno = ERROR;
-		return(a);
-	}
+    /* compute max number of function evaluations */
+    if (a == b) {
+        perror("zerobr: a = b");
+        return (a);
+    }
 
     fb     = (fabs(b) >= fabs(a)) ? fabs(b) : fabs(a);
     tol    = 5.e-1 * t + 2 * meps * fb;
     s      = log(fabs(b - a) / tol) / log(2.);
     maxfun = s * s + 1;
 
-	fa = satm(a);
-	fc = fb = satm(b);
-	if (errno) {
-		return(0.);
-	}
+    fa = satm(a);
+    fc = fb = satm(b);
+    if (errno) {
+        return (0.);
+    }
 
     if (fabs(fb) <= tol)
         return (b);
     if (fabs(fa) <= tol)
         return (a);
 
-	if (fb*fa > 0) {
-		perror("zerobr: root not spanned");
-//		perror("root not spanned:\n\ta %g, b %g, f(a) %g, f(b) %g",
-//			a, b, fa, fb);
-//		errno = ERROR;
-		return(0.);
-	}
+    if (fb * fa > 0) {
+        perror("zerobr: root not spanned");
+        return (0.);
+    }
 
-	while (maxfun--) {
+    while (maxfun--) {
 
-		if ((fb > 0 && fc > 0)  ||  (fb <= 0  && fc <= 0))  {
-			c = a;
-			fc = fa;
-			d = e = b - a;
-		}
+        if ((fb > 0 && fc > 0) || (fb <= 0 && fc <= 0)) {
+            c  = a;
+            fc = fa;
+            d = e = b - a;
+        }
 
         if (fabs(fc) < fabs(fb)) {
             a  = b;
@@ -174,29 +163,29 @@ zerobr(
         if (fabs(e) < tol || fabs(fa) <= fabs(fb))
             d = e = m;
 
-		else {
-			s = fb/fa;
+        else {
+            s = fb / fa;
 
-			if (a == c) {	/* linear interpolation */
-				p = 2 * m * s;
-				q = 1 - s;
-			}
+            if (a == c) { /* linear interpolation */
+                p = 2 * m * s;
+                q = 1 - s;
+            }
 
-			else {		/* inverse quadratic interpolation */
-				q = fa/fc;
-				r = fb/fc;
-				p = s * (2 * m * q * (q-r) - (b-a) * (r-1));
-				q -= 1;
-				q *= (r-1) * (s-1);
-			}
+            else { /* inverse quadratic interpolation */
+                q = fa / fc;
+                r = fb / fc;
+                p = s * (2 * m * q * (q - r) - (b - a) * (r - 1));
+                q -= 1;
+                q *= (r - 1) * (s - 1);
+            }
 
-			if (p > 0)
-				q = -q;
-			else
-				p = -p;
+            if (p > 0)
+                q = -q;
+            else
+                p = -p;
 
-			s = e;
-			e = d;
+            s = e;
+            e = d;
 
             if (2 * p < 3 * m * q - fabs(tol * q) && p < fabs(s * q / 2))
                 d = p / q;
@@ -204,8 +193,8 @@ zerobr(
                 d = e = m;
         }
 
-		a = b;
-		fa = fb;
+        a  = b;
+        fa = fb;
 
         if (fabs(d) > tol)
             b += d;
@@ -214,14 +203,12 @@ zerobr(
         else
             b -= tol;
 
-		fb = satm(b);
-		if (errno) {
-			return(0.);
-		}
-	}
-	perror("did not converge");
+        fb = satm(b);
+        if (errno) {
+            return (0.);
+        }
+    }
+    perror("did not converge");
 
-//	errno = ERROR;
-	return(0.);
+    return (0.);
 }
-

--- a/smrf/envphys/core/envphys.h
+++ b/smrf/envphys/core/envphys.h
@@ -11,11 +11,6 @@
  */
 
 /*
- *  Logarithm 10
- */
-#define LOG_10 log(1.e1)
-
-/*
  *  molecular weight of air (kg / kmole)
  */
 #define MOL_AIR 28.9644

--- a/smrf/envphys/core/envphys.h
+++ b/smrf/envphys/core/envphys.h
@@ -3,9 +3,9 @@
 /*
  * Environmental physics.
  */
- 
+
 /* ----------------------------------------------------------------------- */
- 
+
 /*
  *  Constants
  */
@@ -42,33 +42,6 @@
 #define CP_W0   	4217.7
 
 /*
- *  density of water at 0C (kg/m^3)
- *    (from CRC handbook pg F-11)
- */
-#define RHO_W0  	999.87
-
-/*  density of ice - no air (kg/m^3)
- *    (from CRC handbook pg F-1)
- */
-#define RHO_ICE 	917.0
-
-/*  thermal conductivity of wet sandy soil (J/(m sec K))
- *    (from Oke, 1978, pg. 38)
- */
-#define KT_WETSAND      2.2
-
-/*  thermal conductivity of dry sandy soil (J/(m sec K))
- *    (from Peixoto & Oort, 1992, pg. 221)
- */
-#define KT_DRYSAND      0.3
-
-/*  thermal conductivity of moist sandy soil (J/(m sec K))
- *    (estimated from C. Luces heat flux data at RMSP,
- *	by A. Winstral and D. Marks, NWRC)
- */
-#define KT_MOISTSAND      1.65
-
-/*
  *  standard sea level pressure (Pa)
  */
 #define SEA_LEVEL       1.013246e5
@@ -89,105 +62,20 @@
 #define STD_LAPSE       -6.5
 
 /*
- *  dry adiabatic lapse rate (deg / m)
- */
-#define DALR		( GRAVITY / CP_AIR )
-
-/*
  *  gravitational acceleration at reference latitude 45d 32m 33s (m/s^2)
  */
 #define GRAVITY		9.80665
 
 /*
- *  Earth equivalent spherical radius (km)
+ * Stefan–Boltzmann constant
  */
-#define EARTH_RADIUS	6.37122e3
-
-/*
- *  velocity of light, m/s (Marx, Nature, 296, 11, 1982)
- */
-#define LIGHT_SPEED     2.99722458e8
-
-/*
- *  Von Karman constant
- */
-#define VON_KARMAN      0.41
+#define STEF_BOLTZ 5.6697e-8
 
 /* ------------------------------------------------------------------------ */
- 
+
 /*
  *  Macros
  */
-
-/*
- *  equation of state, to give density of a gas (kg/m^3) 
- *
- *	p = pressure (Pa)
- *	m = molecular weight (kg/kmole)
- *	t = temperature (K)	
- *
- *  or, inversely, to give pressure (Pa)
- *
- *      rho = density (kg/m^3)
- *	m   = molecular weight (kg/kmole)
- *	t   = temperature (K)	
- */
-#define GAS_DEN(p,m,t)          ((p)*(m)/(RGAS*(t)))
-#define EQ_STATE(rho,m,t)       ((rho)*(RGAS)*(t)/(m))
-
-/*
- *  virtual temperature, i.e. the fictitious temperature that air must
- *  have at the given pressure to have the same density as a water vapor
- *  and air mixture at the same pressure with the given temperature and
- *  vapor pressure.
- *
- *      t = temperature (K)
- *      e = vapor pressure
- *	P = pressure (e and P in same units),
- */
-#define VIR_TEMP(t,e,P)		((t)/(1.-(1.-MOL_H2O/MOL_AIR)*((e)/(P))))
-
-/*
- *  inverse of VIR_TEMP
- *
- *      tv = virtual temperature (K)
- *      e  = vapor pressure
- *	P  = pressure (e and P in same units),
- */
-#define INV_VIR_TEMP(tv,e,P)          ((tv)*(1.-(1.-MOL_H2O/MOL_AIR)*((e)/(P))))
-
-/*
- *  potential temperature
- *
- *      t = temperature (K)
- *	p = pressure (Pa)
- */
-#define POT_TEMP(t,p)           ((t)*pow(1.e5/(p),RGAS/(MOL_AIR*CP_AIR)))
-
-/*
- *  inverse of POT_TEMP
- *
- *	theta = potential temperature (K)
- *	p     = pressure (Pa)
- */
-#define	INV_POT_TEMP(theta,p)	((theta)/pow(1.e5/(p),RGAS/(MOL_AIR*CP_AIR)))
-
-/*
- *  specific heat of ice (J/(kg K))
- *    (from CRC table D-159; most accurate from 0 to -10 C)
- *
- *	t = temperature (K)
- */
-#define CP_ICE(t)       ( CAL_TO_J(0.024928 + (0.00176*(t))) / G_TO_KG(1) )
-
-/*
- *  specific heat of water (J/(kg K))
- *    (from CRC table D-158; most accurate from 0 to +10 C)
- *    (incorrect at temperatures above 25 C)
- *
- *	t = temperature (K)
- */
-#define CP_WATER(t)     ( CP_W0 - 2.55*((t)-FREEZE) )
 
 /*
  *  integral of hydrostatic equation over layer with linear temperature
@@ -207,73 +95,6 @@
                 pow((tb)/((tb)+(L)*(h)),(g)*(m)/(RGAS*(L)*1.e-3))))
 
 /*
- *  inverse of integral of hydrostatic equation over layer with linear
- *  temperature variation
- *
- *      pb = base level pressure
- *	tb = base level temp (K)
- *      hb = base level geopotential altitude (km)
- *      p  = level pressure
- *	t  = level temperature (K)
- *      g  = grav accel (m/s^2)
- *	m  = molec wt (kg/kmole)
- *
- *      (the factor 1.e-3 is for units conversion)
- */
-#define INV_HYSTAT(pb,tb,hb,p,t,g,m) ((hb)+\
-	                1.e-3*log((p)/(pb))*(RGAS/((g)*(m)))*\
-	       	        (((tb)==(t)) ? (-(t)) :\
-	                ((t)-(tb))/log((tb)/(t))))
-
-/*
- *  specific humidity from vapor pressure
- *
- *	e = vapor pressure
- *	P = pressure (same units as e)
- */
-#define SPEC_HUM(e,P)     ((e)*MOL_H2O/(MOL_AIR*(P)+(e)*(MOL_H2O-MOL_AIR)))
-
-/*
- *  vapor pressure from specific humidity
- *
- *	q = specific humidity
- *	P = pressure
- */
-#define INV_SPEC_HUM(q,P)  (-MOL_AIR*(P)*(q)/((MOL_H2O-MOL_AIR)*(q)-MOL_H2O))
-
-/*
- *  mixing ratio
- *
- *	e = vapor pressure
- *	P = pressure (same units as e)
- */
-#define MIX_RATIO(e,P)          ((MOL_H2O/MOL_AIR)*(e)/((P)-(e)))
-
-/*
- *  vapor pressure from mixing ratio
- *
- *	w = mixing ratio
- *	P = pressure
- */
-#define INV_MIX_RATIO(w,P)	((w)*(P)/((w)+(MOL_H2O/MOL_AIR)))
-
-/*
- *  vapor pressure from absolute humidity
- *
- *	ah = absolute humidity (gm/m^3)
- *	ta = air temperature (K)
- */
-#define AH2VP(ah,ta)		((ah)*(RGAS/MOL_H2O)*(ta))
-
-/*
- *  absolute humidity from vapor pressure
- *
- *	e = vapor pressure (Pa)
- *	ta = air temperature (K)
- */
-#define VP2AH(e,ta)		((e)*(MOL_H2O/(RGAS*(ta))))
-
-/*
  *  latent heat of vaporization
  *
  *	t = temperature (K)
@@ -287,74 +108,5 @@
  */
 #define LH_FUS(t)               (3.336e5 + 1.6667e2 * (FREEZE - (t)))
 
-/*
- *  latent heat of sublimination (J/kg)
- *    from the sum of latent heats of vaporization and fusion,
- *
- *	t = temperature (K)
- */
-#define LH_SUB(t)       	( LH_VAP(t) + LH_FUS(t) )
-
-
-/*
- *  effectuve diffusion coefficient (m^2/sec) for saturated porous layer
- *  (like snow...).  See Anderson, 1976, pg. 32, eq. 3.13.
- *
- *	pa = air pressure (Pa)
- *	ts = layer temperature (K)
- */
-#define DIFFUS(pa,ts)   ( (0.65*(SEA_LEVEL/(pa)) * \
-                        pow(((ts)/FREEZE),14.0)) * (0.01*0.01) )
-
-/*
- *  water vapor flux (kg/(m^2 sec)) between two layers
- *
- *	air_d = air density (kg/m^3)
- *	k     = diffusion coef. (m^2/sec)
- *	q_dif = specific hum. diff between layers (kg/kg)
- *	z_dif = absolute distance between layers (m)
- *
- *	note:   q_dif controls the sign of the computed flux
- */
-#define EVAP(air_d,k,q_dif,z_dif)       ( air_d * k * (q_dif/z_dif) )
-
-/*
- *  dry static energy (J/kg)
- *    (pg. 332, "Dynamic Meteorology", Holton, J.R., 1979)
- *
- *	t = air temperature (K)
- *	z = elevation (m)
- */
-#define DSE(t,z)        ( (CP_AIR * (t) ) + (GRAVITY * (z) ) )
-
-/*
- *  inverse of DSE: air temperature (K) from dry static energy
- *    (pg. 332, "Dynamic Meteorology", Holton, J.R., 1979)
- *
- *	dse = dry static energy (J/kg)
- *	z   = elevation (m)
- */
-#define INV_DSE(dse,z)  ((dse) - (GRAVITY * (z)) / CP_AIR )
-
-/*
- *  moist static energy (J/kg)
- *    (pg. 332, "Dynamic Meteorology", Holton, J.R., 1979)
- *
- *	z = elevation (m)
- *	t = air temperature (K)
- *	w = mixing ratio
- */
-#define MSE(z,t,w)      ( DSE((t),(z)) + LH_VAP(t) * (w) )
-
-/*
- *  inverse of MSE: vapor press (Pa) from moist static energy
- *    (pg. 332, "Dynamic Meteorology", Holton, J.R., 1979)
- *
- *	z   = elevation (m)
- *	t   = air temperature (K)
- *	mse = moist static energy (J/kg)
- */
-#define INV_MSE(z,t,mse)        ( ((mse) - DSE((t),(z))) / LH_VAP(t) )
-
 /* ------------------------------------------------------------------------ */
- 
+

--- a/smrf/envphys/core/envphys.h
+++ b/smrf/envphys/core/envphys.h
@@ -13,63 +13,73 @@
 /*
  *  Logarithm 10
  */
-#define LOG_10          log(1.e1)
+#define LOG_10 log(1.e1)
 
 /*
  *  molecular weight of air (kg / kmole)
  */
-#define MOL_AIR         28.9644
+#define MOL_AIR 28.9644
 
 /*
  *  molecular weight of water vapor (kg / kmole)
  */
-#define MOL_H2O         18.0153
+#define MOL_H2O 18.0153
 
 /*
  *  gas constant (J / kmole / deg)
  */
-#define RGAS            8.31432e3
+#define RGAS 8.31432e3
+
+/*
+ * Gas constant for water vapor (J/kg/K)
+ */
+#define RH2O 461.5
+
+/*
+ * Ratio of moleculr weights of water and dry air
+ */
+#define EPS (MOL_H2O / MOL_AIR)
 
 /*
  *  triple point of water at standard pressure (deg K)
  */
-#define FREEZE          2.7316e2
-#define BOIL            3.7315e2
+#define FREEZE 2.7316e2
+#define BOIL 3.7315e2
 
 /*
  *  specific heat of air at constant pressure (J / kg / deg)
  */
-#define CP_AIR          1.005e3
+#define CP_AIR 1.005e3
 
 /*
  *  specific heat of water at 0C (J / (kg K))
  */
-#define CP_W0   	4217.7
+#define CP_W0 4217.7
 
 /*
  *  standard sea level pressure (Pa)
  */
-#define SEA_LEVEL       1.013246e5
+#define SEA_LEVEL 1.013246e5
 
 /*
  *  standard sea level air temp (K)
  */
-#define STD_AIRTMP      2.88e2
+#define STD_AIRTMP 2.88e2
 
 /*
  *  standard lapse rate (K/m)
  */
-#define STD_LAPSE_M      -0.0065
+#define STD_LAPSE_M -0.0065
 
 /*
  *  standard lapse rate (K/km)
  */
-#define STD_LAPSE       -6.5
+#define STD_LAPSE -6.5
 
 /*
  *  gravitational acceleration at reference latitude 45d 32m 33s (m/s^2)
  */
-#define GRAVITY		9.80665
+#define GRAVITY 9.80665
 
 /*
  * Stefan–Boltzmann constant
@@ -95,23 +105,23 @@
  *
  *	(the factors 1.e-3 and 1.e3 are for units conversion)
  */
-#define HYSTAT(pb,tb,L,h,g,m)           ((pb) * (((L)==0.) ?\
-                exp(-(g)*(m)*(h)*1.e3/(RGAS*(tb))) :\
-                pow((tb)/((tb)+(L)*(h)),(g)*(m)/(RGAS*(L)*1.e-3))))
+#define HYSTAT(pb, tb, L, h, g, m)                                             \
+  ((pb) * (((L) == 0.) ? exp(-(g) * (m) * (h) * 1.e3 / (RGAS * (tb)))          \
+                       : pow((tb) / ((tb) + (L) * (h)),                        \
+                             (g) * (m) / (RGAS * (L) * 1.e-3))))
 
 /*
  *  latent heat of vaporization
  *
  *	t = temperature (K)
  */
-#define LH_VAP(t)               (2.5e6 - 2.95573e3 *((t) - FREEZE))
+#define LH_VAP(t) (2.5e6 - 2.95573e3 * ((t) - FREEZE))
 
 /*
  *  latent heat of fusion
  *
  *	t = temperature (K)
  */
-#define LH_FUS(t)               (3.336e5 + 1.6667e2 * (FREEZE - (t)))
+#define LH_FUS(t) (3.336e5 + 1.6667e2 * (FREEZE - (t)))
 
 /* ------------------------------------------------------------------------ */
-

--- a/smrf/envphys/core/envphys.h
+++ b/smrf/envphys/core/envphys.h
@@ -9,7 +9,12 @@
 /*
  *  Constants
  */
- 
+
+/*
+ *  Logarithm 10
+ */
+#define LOG_10          log(1.e1)
+
 /*
  *  molecular weight of air (kg / kmole)
  */

--- a/smrf/envphys/core/envphys.h
+++ b/smrf/envphys/core/envphys.h
@@ -39,7 +39,7 @@
  *  triple point of water at standard pressure (deg K)
  */
 #define FREEZE 2.7316e2
-#define BOIL 3.7315e2
+#define BOIL   3.7315e2
 
 /*
  *  specific heat of air at constant pressure (J / kg / deg)
@@ -100,10 +100,10 @@
  *
  *	(the factors 1.e-3 and 1.e3 are for units conversion)
  */
-#define HYSTAT(pb, tb, L, h, g, m)                                             \
-  ((pb) * (((L) == 0.) ? exp(-(g) * (m) * (h) * 1.e3 / (RGAS * (tb)))          \
-                       : pow((tb) / ((tb) + (L) * (h)),                        \
-                             (g) * (m) / (RGAS * (L) * 1.e-3))))
+#define HYSTAT(pb, tb, L, h, g, m)                                 \
+    ((pb)                                                          \
+     * (((L) == 0.) ? exp(-(g) * (m) * (h) * 1.e3 / (RGAS * (tb))) \
+                    : pow((tb) / ((tb) + (L) * (h)), (g) * (m) / (RGAS * (L) * 1.e-3))))
 
 /*
  *  latent heat of vaporization

--- a/smrf/envphys/core/envphys_c.h
+++ b/smrf/envphys/core/envphys_c.h
@@ -6,6 +6,7 @@
 /* From topotherm.c */
 
 void topotherm(int ngrid, double *ta, double *tw, double *z, double *skvfac, int nthreads, double *thermal);
+double saturation_vapor_pressure(double *ta);
 double satw(double tk);
 double sati(double tk);
 double brutsaert(double ta, double lmba, double ea, double z, double pa);

--- a/smrf/envphys/core/envphys_c.h
+++ b/smrf/envphys/core/envphys_c.h
@@ -1,11 +1,7 @@
-
-#define ABS(x)			( (x) < 0 ? -(x) : (x) )
-
-#define DBL_EPSILON 2.2204460492503131e-16
-
 /* From topotherm.c */
-
-void topotherm(int ngrid, double *ta, double *tw, double *z, double *skvfac, int nthreads, double *thermal);
+void topotherm(
+    int ngrid, double *ta, double *tw, double *z, double *skvfac, int nthreads, double *thermal
+);
 double saturation_vapor_pressure(double *ta);
 double satw(double tk);
 double sati(double tk);
@@ -14,8 +10,8 @@ double brutsaert(double ta, double lmba, double ea, double z, double pa);
 /* from dewpt.c */
 void dewpt(int ngrid, double *ea, int nthreads, double tol, double *dpt);
 double dew_pointp(double e, double tol);
-double	zerobr(double a, double b, double t);
+double zerobr(double a, double b, double t);
 
 /* from iwbt.c */
-void iwbt(int ngrid, double *ta, double *td,	double *z, int nthreads, double tol,	double *tw);
-double wetbulb(double	ta,	double dpt, double press, double tol);
+void iwbt(int ngrid, double *ta, double *td, double *z, int nthreads, double tol, double *tw);
+double wetbulb(double ta, double dpt, double press, double tol);

--- a/smrf/envphys/core/envphys_c.pyx
+++ b/smrf/envphys/core/envphys_c.pyx
@@ -36,7 +36,7 @@ def svp_for_temperatures(double[:, ::1] temperature_k, double[:, ::1] output_arr
         for j in range(cols):
             value = temperature_k[i, j]
 
-            if value <= 0.0 or np.isnan(value):
+            if value <= 0.0 or value != value:  # The latter checks for NaN
                 output_array[i, j] = np.nan
             else:
                 output_array[i, j] = saturation_vapor_pressure(&value)

--- a/smrf/envphys/core/envphys_c.pyx
+++ b/smrf/envphys/core/envphys_c.pyx
@@ -1,14 +1,6 @@
-# cython: embedsignature=True
-# cython: language_level=3
-"""
-C implementation of some radiation functions
-"""
-
-
-import cython
-import numpy as np
-
-cimport numpy as np
+cimport numpy as np # noqa
+cimport cython # noqa
+import numpy as np # noqa
 
 # Numpy must be initialized. When using numpy from C or Cython you must
 # _always_ do that, or you will have segfaults
@@ -16,13 +8,40 @@ np.import_array()
 
 
 cdef extern from "envphys_c.h":
-    void topotherm(int ngrid, double *ta, double *tw, double *z, double *skvfac, int nthreads, double *thermal);
-    void dewpt(int ngrid, double *ea, int nthreads, double tol, double *dpt);
-    void iwbt(int ngrid, double *ta, double *td,	double *z, int nthreads, double tol, double *tw);
+    void topotherm(int ngrid, double *ta, double *tw, double *z, double *skvfac, int nthreads, double *thermal)
+    void dewpt(int ngrid, double *ea, int nthreads, double tol, double *dpt)
+    void iwbt(int ngrid, double *ta, double *td,	double *z, int nthreads, double tol, double *tw)
+    double saturation_vapor_pressure(double *ta)
 
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
+def svp_for_temperatures(double[:, ::1] temperature_k, double[:, ::1] output_array):
+    """
+    Wrapper function to calculate the saturation vapor pressure for given temperature.
+
+    This is not parallelized since the math is very minimal and only serves to reduce
+    duplicated code when trying to apply this to a numpy array.
+    Main use:
+    * :mod:`smrf.envphys.vapor_pressure`
+
+    Args:
+        temperature_k: Input array with air temperatures
+        output_array: Output array to write the results to
+    """
+    cdef Py_ssize_t i, j
+    cdef Py_ssize_t rows = temperature_k.shape[0]
+    cdef Py_ssize_t cols = temperature_k.shape[1]
+    cdef double value
+
+    for i in range(rows):
+        for j in range(cols):
+            value = temperature_k[i, j]
+
+            if value <= 0.0 or np.isnan(value):
+                output_array[i, j] = np.nan
+            else:
+                output_array[i, j] = saturation_vapor_pressure(&value)
+
+
 # https://github.com/cython/cython/wiki/tutorials-NumpyPointerToC
 def ctopotherm(np.ndarray[double, mode="c", ndim=2] ta,
                np.ndarray[double, mode="c", ndim=2] tw,
@@ -67,8 +86,6 @@ def ctopotherm(np.ndarray[double, mode="c", ndim=2] ta,
     return None
 
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
 # https://github.com/cython/cython/wiki/tutorials-NumpyPointerToC
 def cdewpt(np.ndarray[double, mode="c", ndim=2] vp,
                np.ndarray[double, mode="c", ndim=2] dwpt not None,
@@ -97,8 +114,6 @@ def cdewpt(np.ndarray[double, mode="c", ndim=2] vp,
     return None
 
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
 # https://github.com/cython/cython/wiki/tutorials-NumpyPointerToC
 def cwbt(np.ndarray[double, mode="c", ndim=2] ta,
          np.ndarray[double, mode="c", ndim=2] td,

--- a/smrf/envphys/core/iwbt.c
+++ b/smrf/envphys/core/iwbt.c
@@ -1,137 +1,126 @@
-//iwbt -- compute wet or icebult from air and dewpoint temperatures
-
+#include "envphys.h"
+#include "envphys_c.h"
+#include <omp.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
-#include <errno.h>
-#include <omp.h>
-#include "envphys_c.h"
-#include "envphys.h"
 
-#define RH2O 461.5		/* Gas constant for water vapor (J/kg/K) */
-#define EPS (MOL_H2O/MOL_AIR)	/* Ratio of moleculr weights of water and dry air */
-//#define CONVERGE 0.1		/* Convergence value */
-
+/*
+ * Calculate the wet bulb temperature
+ */
 double wetbulb(
-	double	ta,	/* air tempterature (K) */
-	double	dpt,	/* dewpoint temperature (K) */
-	double	press,	/* total air pressure (Pa)  */
-	double	tol)		/* wet_bulb tolerance threshold */
-{
-	int	i;
-	double	ea;	/* vapor pressure (Pa) */
-	double	esat;	/* saturation ea @ Ta (Pa) */
-	double	xlh;	/* latent heat of vaporization + fusion (sublimation) (J/kg) */
-	double	xlhv;	/* latent heat of vaporization *(J/kg) */
-	double	xlhf;	/* latent heat of fusion *(J/kg) */
-	double	fu_fac;	/* fudge factor for xlh stradeling 0 */
-	double	psyc;	/* Psychrometric "constant" (K/Pa) */
-	double	dedt;	/* Change in ea with temperature (Pa/K) */
-	double	pf;	/* Psychrometer value (K) */
-	double	dpdt;	/* Change in pf with temperature */
-	double	ti;	/* wet or ice bulb temperature (K) */
-	double	ti0;	/* initial value for ti */
-	double	dti;	/* closure value */
+    double ta,    /* air tempterature (K) */
+    double dpt,   /* dewpoint temperature (K) */
+    double press, /* total air pressure (Pa)  */
+    double tol    /* wet_bulb tolerance threshold */
+) {
+    int i;
+    double ea;     /* vapor pressure (Pa) */
+    double esat;   /* saturation ea @ Ta (Pa) */
+    double xlh;    /* latent heat of vaporization + fusion (sublimation) (J/kg) */
+    double xlhv;   /* latent heat of vaporization *(J/kg) */
+    double xlhf;   /* latent heat of fusion *(J/kg) */
+    double fu_fac; /* fudge factor for xlh stradeling 0 */
+    double psyc;   /* Psychrometric "constant" (K/Pa) */
+    double dedt;   /* Change in ea with temperature (Pa/K) */
+    double pf;     /* Psychrometer value (K) */
+    double dpdt;   /* Change in pf with temperature */
+    double ti;     /* wet or ice bulb temperature (K) */
+    double ti0;    /* initial value for ti */
+    double dti;    /* closure value */
 
-	/* find latent heat of vaporization, or vaporization + fusion */
-	if (ta <= FREEZE) {
-		xlhv = LH_VAP((ta + dpt) / 2.0);
-		xlhf = LH_FUS((ta + dpt) / 2.0);
-		xlh  = xlhv + xlhf;
-	}
-	else if (dpt <= FREEZE) {
-		xlhv = LH_VAP((ta + dpt) / 2.0);
-		xlhf = LH_FUS((FREEZE + dpt) / 2.0);
-		fu_fac = ((FREEZE - dpt) / (ta - dpt));
-		xlh  = xlhv + (fu_fac * xlhf);
-	}
-	else
-		xlh = LH_VAP((ta+dpt)/2);
+    /* find latent heat of vaporization, or vaporization + fusion */
+    if (ta <= FREEZE) {
+        xlhv = LH_VAP((ta + dpt) / 2.0);
+        xlhf = LH_FUS((ta + dpt) / 2.0);
+        xlh = xlhv + xlhf;
+    } else if (dpt <= FREEZE) {
+        xlhv = LH_VAP((ta + dpt) / 2.0);
+        xlhf = LH_FUS((FREEZE + dpt) / 2.0);
+        fu_fac = ((FREEZE - dpt) / (ta - dpt));
+        xlh = xlhv + (fu_fac * xlhf);
+    } else
+        xlh = LH_VAP((ta + dpt) / 2);
 
-	/* vapor pressure and saturation vapor pressure at ta */
-	ea = sati(dpt);
-	esat = sati(ta);
-	/* Psychrometric "constant" (K/Pa) */
-	psyc = EPS * (xlh / (CP_AIR * press));
+    /* vapor pressure and saturation vapor pressure at ta */
     ea = saturation_vapor_pressure(&dpt);
     esat = saturation_vapor_pressure(&ta);
+    /* Psychrometric "constant" (K/Pa) */
+    psyc = EPS * (xlh / (CP_AIR * press));
 
-	/* solve for wet or ice bulb temperature */
-	dti = 1.0;
-	i = 0;
-	ti = ta;
-	while (dti > tol) {
-		ti0 = ti;
-		if (ti != ta)
-			esat = sati(ti);
-		dedt = xlh * (esat / (RH2O * (ti*ti)));
-		pf = (ti - ta) + (psyc * (esat - ea));
-		dpdt = 1.0 + (psyc * dedt);
-		ti = ti - (pf / dpdt);
-		dti = ti0 - ti;
-		i++;
-		if (i > 10){
-			printf("failure to converge in 10 iterations");
-			exit(-1);
-		}
-	}
-	return(ti);
+    /* solve for wet or ice bulb temperature */
+    dti = 1.0;
+    i = 0;
+    ti = ta;
+    while (dti > tol) {
+        ti0 = ti;
+        if (ti != ta)
             esat = saturation_vapor_pressure(&ti);
+        dedt = xlh * (esat / (RH2O * (ti * ti)));
+        pf = (ti - ta) + (psyc * (esat - ea));
+        dpdt = 1.0 + (psyc * dedt);
+        ti = ti - (pf / dpdt);
+        dti = ti0 - ti;
+        i++;
+        if (i > 10) {
+            printf("failure to converge in 10 iterations");
+            exit(-1);
+        }
+    }
+    return (ti);
 }
 
-//Function to calculate the wet bult temeprature of the whole image
-void iwbt (
-		int ngrid,		/* number of grid points */
-		double *ta,		/* air temperature */
-		double *td,		/* dew point temperature */
-		double *z,		/* elevation */
-		int nthreads,	/* number of threads for parrallel processing */
-		double tol,		/* wet_bulb tolerance threshold */
-		double *tw)		/* wet bulb temperature (return) */
-{
-	int samp;
-	double		td_p;		/* dew point temperature (C)	*/
-	double		tw_p;		/* wet bulb temperature (C)	*/
-	double		ta_p;		/* air temperature (C)		*/
-	double		z_p;		/* elevation (m)		*/
-	double		pa_p;		/* air pressure (pa)		*/
+/*
+ * Function to calculate the wet bult temeprature of the whole image
+ */
+void iwbt(
+    int ngrid,    /* number of grid points */
+    double *ta,   /* air temperature */
+    double *td,   /* dew point temperature */
+    double *z,    /* elevation */
+    int nthreads, /* number of threads for parrallel processing */
+    double tol,   /* wet_bulb tolerance threshold */
+    double *tw    /* wet bulb temperature (return) */
+) {
+    int samp;
+    double td_p; /* dew point temperature (C) */
+    double tw_p; /* wet bulb temperature (C) */
+    double ta_p; /* air temperature (C)	*/
+    double z_p;  /* elevation (m) */
+    double pa_p; /* air pressure (pa) */
 
-	omp_set_dynamic(0);     // Explicitly disable dynamic teams
-	omp_set_num_threads(nthreads); // Use N threads for all consecutive parallel regions
+    omp_set_dynamic(0);            // Explicitly disable dynamic teams
+    omp_set_num_threads(nthreads); // Use N threads for all consecutive parallel regions
 
 #pragma omp parallel shared(ngrid, ta, td, z) private(samp, ta_p, tw_p, z_p, pa_p, td_p)
-	{
+    {
+
 #pragma omp for
+        for (samp = 0; samp < ngrid; samp++) {
+            // get pixel values
+            ta_p = ta[samp];
+            td_p = td[samp];
+            z_p = z[samp];
 
-		for (samp=0; samp < ngrid; samp++) {
-			// get pixel values
-			ta_p = ta[samp];
-			td_p = td[samp];
-			z_p = z[samp];
+            /*	set pa	*/
+            if (z_p == 0.0) {
+                pa_p = SEA_LEVEL;
+            } else {
+                pa_p = HYSTAT(SEA_LEVEL, STD_AIRTMP, STD_LAPSE, (z_p / 1000.0), GRAVITY, MOL_AIR);
+            }
 
-			/*	set pa	*/
-			if (z_p == 0.0) {
-				pa_p = SEA_LEVEL;
-			}
-			else {
-				pa_p = HYSTAT (SEA_LEVEL, STD_AIRTMP, STD_LAPSE,
-							(z_p / 1000.0), GRAVITY, MOL_AIR);
-			}
+            /*	convert ta & td to Kelvin	*/
+            ta_p += FREEZE;
+            td_p += FREEZE;
 
-			/*	convert ta & td to Kelvin	*/
-			ta_p += FREEZE;
-			td_p += FREEZE;
+            if (ta_p < 0 || td_p < 0) {
+                printf("ta or td < 0 at pixel %i", samp);
+                exit(-1);
+            }
+            /*	call wetbulb function & fill output buffer	*/
+            tw_p = wetbulb(ta_p, td_p, pa_p, tol);
 
-			if(ta_p < 0 || td_p < 0){
-				printf("ta or td < 0 at pixel %i", samp);
-				exit(-1);
-			}
-			/*	call wetbulb function & fill output buffer	*/
-			tw_p = wetbulb(ta_p, td_p, pa_p, tol);
-
-			// put back in array
-			tw[samp] = tw_p - FREEZE;
-			}
-		}
-
+            // put back in array
+            tw[samp] = tw_p - FREEZE;
+        }
+    }
 }

--- a/smrf/envphys/core/iwbt.c
+++ b/smrf/envphys/core/iwbt.c
@@ -53,6 +53,8 @@ double wetbulb(
 	esat = sati(ta);
 	/* Psychrometric "constant" (K/Pa) */
 	psyc = EPS * (xlh / (CP_AIR * press));
+    ea = saturation_vapor_pressure(&dpt);
+    esat = saturation_vapor_pressure(&ta);
 
 	/* solve for wet or ice bulb temperature */
 	dti = 1.0;
@@ -74,6 +76,7 @@ double wetbulb(
 		}
 	}
 	return(ti);
+            esat = saturation_vapor_pressure(&ti);
 }
 
 //Function to calculate the wet bult temeprature of the whole image

--- a/smrf/envphys/core/iwbt.c
+++ b/smrf/envphys/core/iwbt.c
@@ -32,34 +32,34 @@ double wetbulb(
     if (ta <= FREEZE) {
         xlhv = LH_VAP((ta + dpt) / 2.0);
         xlhf = LH_FUS((ta + dpt) / 2.0);
-        xlh = xlhv + xlhf;
+        xlh  = xlhv + xlhf;
     } else if (dpt <= FREEZE) {
-        xlhv = LH_VAP((ta + dpt) / 2.0);
-        xlhf = LH_FUS((FREEZE + dpt) / 2.0);
+        xlhv   = LH_VAP((ta + dpt) / 2.0);
+        xlhf   = LH_FUS((FREEZE + dpt) / 2.0);
         fu_fac = ((FREEZE - dpt) / (ta - dpt));
-        xlh = xlhv + (fu_fac * xlhf);
+        xlh    = xlhv + (fu_fac * xlhf);
     } else
         xlh = LH_VAP((ta + dpt) / 2);
 
     /* vapor pressure and saturation vapor pressure at ta */
-    ea = saturation_vapor_pressure(&dpt);
+    ea   = saturation_vapor_pressure(&dpt);
     esat = saturation_vapor_pressure(&ta);
     /* Psychrometric "constant" (K/Pa) */
     psyc = EPS * (xlh / (CP_AIR * press));
 
     /* solve for wet or ice bulb temperature */
     dti = 1.0;
-    i = 0;
-    ti = ta;
+    i   = 0;
+    ti  = ta;
     while (dti > tol) {
         ti0 = ti;
         if (ti != ta)
             esat = saturation_vapor_pressure(&ti);
         dedt = xlh * (esat / (RH2O * (ti * ti)));
-        pf = (ti - ta) + (psyc * (esat - ea));
+        pf   = (ti - ta) + (psyc * (esat - ea));
         dpdt = 1.0 + (psyc * dedt);
-        ti = ti - (pf / dpdt);
-        dti = ti0 - ti;
+        ti   = ti - (pf / dpdt);
+        dti  = ti0 - ti;
         i++;
         if (i > 10) {
             printf("failure to converge in 10 iterations");
@@ -99,7 +99,7 @@ void iwbt(
             // get pixel values
             ta_p = ta[samp];
             td_p = td[samp];
-            z_p = z[samp];
+            z_p  = z[samp];
 
             /*	set pa	*/
             if (z_p == 0.0) {

--- a/smrf/envphys/core/topotherm.c
+++ b/smrf/envphys/core/topotherm.c
@@ -8,94 +8,80 @@
 
 extern int errno;
 
+void topotherm(int ngrid,      /* number of grid points */
+               double *ta,     /* air temperature */
+               double *tw,     /* dew point temperature */
+               double *z,      /* elevation */
+               double *skvfac, /* sky view factor */
+               int nthreads,   /* number of threads for parrallel processing */
+               double *thermal /* thermal radiation (return) */
+) {
+  int samp;
+  double ta_p, tw_p, z_p, skvfac_p; // pixel values
+  double ea;                        /*	vapor pressure */
+  double emiss;                     /*	atmos. emiss.  */
+  double T0;                        /*	Sea Level ta   */
+  double lw_in;                     /*	lw irradiance  */
+  double press;                     /*	air pressure   */
 
-void topotherm(
-		int ngrid,		/* number of grid points */
-		double *ta,		/* air temperature */
-		double *tw,		/* dew point temperature */
-		double *z,		/* elevation */
-		double *skvfac,	/* sky view factor */
-		int nthreads,	/* number of threads for parrallel processing */
-		double *thermal	/* thermal radiation (return) */
-)
-{
-	int samp;
-	double ta_p, tw_p, z_p, skvfac_p; // pixel values
-	double ea;			/*	vapor pressure		*/
-	double emiss;		/*	atmos. emiss.		*/
-	double T0;			/*	Sea Level ta		*/
-	double lw_in;		/*	lw irradiance		*/
-	double press;		/*	air pressure		*/
+  omp_set_dynamic(0); // Disable dynamic teams
+  omp_set_num_threads(nthreads);
 
-
-	omp_set_dynamic(0);     // Explicitly disable dynamic teams
-	omp_set_num_threads(nthreads); // Use N threads for all consecutive parallel regions
-
-#pragma omp parallel shared(ngrid, ta, tw, z, skvfac) private(samp, ta_p, tw_p, z_p, skvfac_p, ea, emiss, T0, press, lw_in)
-	{
+#pragma omp parallel shared(ngrid, ta, tw, z, skvfac) private(                 \
+        samp, ta_p, tw_p, z_p, skvfac_p, ea, emiss, T0, press, lw_in)
+  {
 #pragma omp for
+    for (samp = 0; samp < ngrid; samp++) {
 
-		for (samp=0; samp < ngrid; samp++) {
+      ta_p = ta[samp];
+      tw_p = tw[samp];
+      z_p = z[samp];
+      skvfac_p = skvfac[samp];
 
-			ta_p = ta[samp];
-			tw_p = tw[samp];
-			z_p = z[samp];
-			skvfac_p = skvfac[samp];
+      /* convert ta and tw from C to K */
+      ta_p += FREEZE;
+      tw_p += FREEZE;
 
-			/* convert ta and tw from C to K */
-			ta_p += FREEZE;
-			tw_p += FREEZE;
+      if (ta_p < 0 || tw_p < 0) {
+        printf("ta or tw < 0 at pixel %i", samp);
+        exit(-1);
+      }
 
-			if(ta_p < 0 || tw_p < 0){
-				printf("ta or tw < 0 at pixel %i", samp);
-				exit(-1);
-			}
+      /* calculate theoretical sea level	*/
+      /* atmospheric emissivity  */
+      /* from reference level ta, tw, and z */
 
-			/*	calculate theoretical sea level	*/
-			/*	atmospheric emissivity  */
-			/*	from reference level ta, tw, and z */
+      if (tw_p > ta_p) {
+        tw_p = ta_p;
+      }
 
-			if(tw_p > ta_p) {
-				tw_p = ta_p;
-			}
+      ea = saturation_vapor_pressure(&tw_p);
+      emiss = brutsaert(ta_p, STD_LAPSE_M, ea, z_p, SEA_LEVEL);
 
-			ea = saturation_vapor_pressure(&tw_p);
-			emiss = brutsaert(ta_p,
-					STD_LAPSE_M, ea,
-					z_p, SEA_LEVEL);
+      /* calculate sea level air temp */
 
-			/*	calculate sea level air temp	*/
+      T0 = ta_p - (z_p * STD_LAPSE_M);
 
-			T0 = ta_p - (z_p * STD_LAPSE_M);
+      /* adjust emiss for elev, terrain, veg, and cloud shading	*/
+      press = HYSTAT(SEA_LEVEL, T0, STD_LAPSE, (z_p / 1000.), GRAVITY, MOL_AIR);
 
-			/*	adjust emiss for elev, terrain	*/
-			/*	     veg, and cloud shading	*/
+      /* elevation correction */
+      emiss *= press / SEA_LEVEL;
 
-			press = HYSTAT(SEA_LEVEL, T0,
-					STD_LAPSE, (z_p/1000.),
-					GRAVITY, MOL_AIR);
+      /* terrain factor correction */
+      emiss = (emiss * skvfac_p) + (1.0 - skvfac_p);
 
-			/* elevation correction */
-			emiss *= press/SEA_LEVEL;
+      /* check for emissivity > 1.0 */
+      if (emiss > 1.0)
+        emiss = 1.0;
 
-			/* terrain factor correction */
-			emiss = (emiss * skvfac_p) + (1.0 - skvfac_p);
+      /*	calculate incoming lw rad	*/
+      lw_in = emiss * STEF_BOLTZ * ta_p * ta_p * ta_p * ta_p;
 
-			/* check for emissivity > 1.0 */
-			if (emiss > 1.0)
-				emiss = 1.0;
-
-			/*	calculate incoming lw rad	*/
-
-			lw_in = emiss * STEF_BOLTZ *ta_p*ta_p*ta_p*ta_p;
-
-			/* set output band */
-
-			thermal[samp] = lw_in;
-
-		}
-	}
-
+      /* set output band */
+      thermal[samp] = lw_in;
+    }
+  }
 }
 
 /*
@@ -103,8 +89,9 @@ void topotherm(
  * Originally from IPW `satw()`
  *
  * References:
- *      World Meteorological Organization (1988), General Meteorology, WMO-No. 49,
- *      Technical Regulations, Volume I, Appendix A, Geneva, Switzerland.
+ *      World Meteorological Organization (1988), General Meteorology,
+ *      WMO-No. 49, Technical Regulations, Volume I, Appendix A, Geneva,
+ *      Switzerland.
  *
  * Arguments:
  *      tk - air temperature (Kelvin)
@@ -132,11 +119,12 @@ double satw(double tk) {
  *  Originally from IPW `sati()`
  *
  *  References:
- *      Goff, J. A., and S. Gratch (1946), Low-pressure properties of water from −160 to 212 F,
- *      Transactions of the American Society of Heating and Ventilating Engineers, 52, 95–122.
+ *      Goff, J. A., and S. Gratch (1946), Low-pressure properties of water from
+ *      −160 to 212 F, Transactions of the American Society of Heating and
+ *      Ventilating Engineers, 52, 95–122.
  *
- *      List, R. J. (1951), Smithsonian Meteorological Tables, 6th Revised Edition,
- *      Smithsonian Institution, Washington, D.C.
+ *      List, R. J. (1951), Smithsonian Meteorological Tables, 6th Revised
+ * Edition, Smithsonian Institution, Washington, D.C.
  *
  * Arguments:
  *      tk - air temperature (Kelvin)
@@ -157,47 +145,47 @@ double sati(double tk) {
 }
 
 /*
- * Wrapper function to calculate saturation vapor pressure depending on temperature.
+ * Wrapper function to calculate saturation vapor pressure depending on
+ * temperature.
  *
  * Arguments:
  *      temperature - air temperature (Kelvin)
  */
 double saturation_vapor_pressure(double *temperature) {
-	if (*temperature > FREEZE) {
-		return(satw(*temperature));
-	} else {
-		return(sati(*temperature));
-	}
+  if (*temperature > FREEZE) {
+    return (satw(*temperature));
+  } else {
+    return (sati(*temperature));
+  }
 }
 
 /*
- * calculates atmospheric emissivity using a modified form of the equations by W. Brutsaert
+ * calculates atmospheric emissivity using a modified form of the equations by
+ * W. Brutsaert
  */
-double
-brutsaert(
-		double   ta,		/* air temp (K)				*/
-		double   lmba,		/* temperature lapse rate (deg/m)	*/
-		double   ea,		/* vapor pressure (Pa)			*/
-		double   z,			/* elevation (z)			*/
-		double   pa)		/* air pressure (Pa)			*/
+double brutsaert(double ta,   /* air temp (K)				*/
+                 double lmba, /* temperature lapse rate (deg/m)	*/
+                 double ea,   /* vapor pressure (Pa)			*/
+                 double z,    /* elevation (z)			*/
+                 double pa)   /* air pressure (Pa)			*/
 {
-	double 	t_prime;
-	double 	rh;
-	double 	e_prime;
-	double 	air_emiss;
+  double t_prime;
+  double rh;
+  double e_prime;
+  double air_emiss;
 
-	t_prime = ta - (lmba * z);
-	rh = ea / saturation_vapor_pressure(&ta);
-	if (rh > 1.0) {
-		rh = 1.0;
-	}
-	e_prime = (rh * saturation_vapor_pressure(&t_prime))/100.0;
+  t_prime = ta - (lmba * z);
+  rh = ea / saturation_vapor_pressure(&ta);
+  if (rh > 1.0) {
+    rh = 1.0;
+  }
+  e_prime = (rh * saturation_vapor_pressure(&t_prime)) / 100.0;
 
-	air_emiss = (1.24*pow((e_prime/t_prime), 1./7.))*pa/SEA_LEVEL;
-	/* "if" statement below is new */
-	if (air_emiss > 1.0) {
-		air_emiss = 1.0;
-	}
+  air_emiss = (1.24 * pow((e_prime / t_prime), 1. / 7.)) * pa / SEA_LEVEL;
+  /* "if" statement below is new */
+  if (air_emiss > 1.0) {
+    air_emiss = 1.0;
+  }
 
-	return(air_emiss);
+  return (air_emiss);
 }

--- a/smrf/envphys/core/topotherm.c
+++ b/smrf/envphys/core/topotherm.c
@@ -1,14 +1,10 @@
-
+#include "envphys.h"
+#include "envphys_c.h"
+#include <errno.h>
+#include <math.h>
+#include <omp.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
-#include <errno.h>
-#include <omp.h>
-#include "envphys_c.h"
-#include "envphys.h"
-
-// stephman boltzman constant
-#define STEF_BOLTZ 5.6697e-8
 
 extern int errno;
 
@@ -63,7 +59,7 @@ void topotherm(
 				tw_p = ta_p;
 			}
 
-			ea = sati(tw_p);
+			ea = saturation_vapor_pressure(&tw_p);
 			emiss = brutsaert(ta_p,
 					STD_LAPSE_M, ea,
 					z_p, SEA_LEVEL);
@@ -102,73 +98,77 @@ void topotherm(
 
 }
 
-
 /*
- * Saturation vapor pressure over water
+ * Saturation vapor pressure over water using Goff-Gratch formulations.
+ * Originally from IPW `satw()`
+ *
+ * References:
+ *      World Meteorological Organization (1988), General Meteorology, WMO-No. 49,
+ *      Technical Regulations, Volume I, Appendix A, Geneva, Switzerland.
+ *
+ * Arguments:
+ *      tk - air temperature (Kelvin)
  */
-double
-satw(
-		double tk)		/* air temperature (K)		*/
-{
-	double  x;
-	double  l10;
+double satw(double tk) {
+  double x;
+  errno = 0;
 
-	if (tk <= 0.) {
-		printf("tk < 0 satw");
-		exit(-1);
-	}
+  x = -7.90298 * (BOIL / tk - 1.) + 5.02808 * log(BOIL / tk) / LOG_10 -
+      1.3816e-7 * (pow(1.e1, 1.1344e1 * (1. - tk / BOIL)) - 1.) +
+      8.1328e-3 * (pow(1.e1, -3.49149 * (BOIL / tk - 1.)) - 1.) +
+      log(SEA_LEVEL) / LOG_10;
 
-	errno = 0;
-	l10 = log(1.e1);
+  x = pow(1.e1, x);
 
-	x = -7.90298*(BOIL/tk-1.) + 5.02808*log(BOIL/tk)/l10 -
-			1.3816e-7*(pow(1.e1,1.1344e1*(1.-tk/BOIL))-1.) +
-			8.1328e-3*(pow(1.e1,-3.49149*(BOIL/tk-1.))-1.) +
-			log(SEA_LEVEL)/l10;
+  if (errno) {
+    perror("satw: bad return from log or pow");
+  }
 
-	x = pow(1.e1,x);
-
-	if (errno) {
-		perror("satw: bad return from log or pow");
-	}
-
-	return(x);
+  return (x);
 }
 
-
 /*
- * Saturation vapor pressure over ice
+ *  Saturation vapor pressure over ice using Goff-Gratch formulations.
+ *  Originally from IPW `sati()`
+ *
+ *  References:
+ *      Goff, J. A., and S. Gratch (1946), Low-pressure properties of water from −160 to 212 F,
+ *      Transactions of the American Society of Heating and Ventilating Engineers, 52, 95–122.
+ *
+ *      List, R. J. (1951), Smithsonian Meteorological Tables, 6th Revised Edition,
+ *      Smithsonian Institution, Washington, D.C.
+ *
+ * Arguments:
+ *      tk - air temperature (Kelvin)
  */
-double
-sati(
-		double tk)		/* air temperature (K)	*/
-{
-	double  l10;
-	double  x;
+double sati(double tk) {
+  double x;
+  errno = 0;
 
-	if (tk <= 0.) {
-		printf("tk < 0 satw");
-		exit(-1);
-	}
+  x = pow(1.e1, -9.09718 * ((FREEZE / tk) - 1.) -
+                    3.56654 * log(FREEZE / tk) / LOG_10 +
+                    8.76793e-1 * (1. - (tk / FREEZE)) + log(6.1071) / LOG_10);
 
-	if (tk > FREEZE) {
-		x = satw(tk);
-		return(x);
-	}
+  if (errno) {
+    perror("sati: bad return from log or pow");
+  }
 
-	errno = 0;
-	l10 = log(1.e1);
-
-	x = pow(1.e1,-9.09718*((FREEZE/tk)-1.) - 3.56654*log(FREEZE/tk)/l10 +
-			8.76793e-1*(1.-(tk/FREEZE)) + log(6.1071)/l10);
-
-	if (errno) {
-		perror("sati: bad return from log or pow");
-	}
-
-	return(x*1.e2);
+  return (x * 1.e2);
 }
 
+/*
+ * Wrapper function to calculate saturation vapor pressure depending on temperature.
+ *
+ * Arguments:
+ *      temperature - air temperature (Kelvin)
+ */
+double saturation_vapor_pressure(double *temperature) {
+	if (*temperature > FREEZE) {
+		return(satw(*temperature));
+	} else {
+		return(sati(*temperature));
+	}
+}
 
 /*
  * calculates atmospheric emissivity using a modified form of the equations by W. Brutsaert
@@ -187,12 +187,11 @@ brutsaert(
 	double 	air_emiss;
 
 	t_prime = ta - (lmba * z);
-	rh = ea / sati(ta);
+	rh = ea / saturation_vapor_pressure(&ta);
 	if (rh > 1.0) {
 		rh = 1.0;
 	}
-	e_prime = (rh * sati(t_prime))/100.0;
-	/*	e_prime = rh * sati(t_prime);	*/
+	e_prime = (rh * saturation_vapor_pressure(&t_prime))/100.0;
 
 	air_emiss = (1.24*pow((e_prime/t_prime), 1./7.))*pa/SEA_LEVEL;
 	/* "if" statement below is new */

--- a/smrf/envphys/core/topotherm.c
+++ b/smrf/envphys/core/topotherm.c
@@ -100,10 +100,10 @@ double satw(double tk) {
   double x;
   errno = 0;
 
-  x = -7.90298 * (BOIL / tk - 1.) + 5.02808 * log(BOIL / tk) / LOG_10 -
+  x = -7.90298 * (BOIL / tk - 1.) + 5.02808 * log(BOIL / tk) / M_LN10 -
       1.3816e-7 * (pow(1.e1, 1.1344e1 * (1. - tk / BOIL)) - 1.) +
       8.1328e-3 * (pow(1.e1, -3.49149 * (BOIL / tk - 1.)) - 1.) +
-      log(SEA_LEVEL) / LOG_10;
+      log(SEA_LEVEL) / M_LN10;
 
   x = pow(1.e1, x);
 
@@ -134,8 +134,8 @@ double sati(double tk) {
   errno = 0;
 
   x = pow(1.e1, -9.09718 * ((FREEZE / tk) - 1.) -
-                    3.56654 * log(FREEZE / tk) / LOG_10 +
-                    8.76793e-1 * (1. - (tk / FREEZE)) + log(6.1071) / LOG_10);
+                    3.56654 * log(FREEZE / tk) / M_LN10 +
+                    8.76793e-1 * (1. - (tk / FREEZE)) + log(6.1071) / M_LN10);
 
   if (errno) {
     perror("sati: bad return from log or pow");

--- a/smrf/envphys/core/topotherm.c
+++ b/smrf/envphys/core/topotherm.c
@@ -8,80 +8,81 @@
 
 extern int errno;
 
-void topotherm(int ngrid,      /* number of grid points */
-               double *ta,     /* air temperature */
-               double *tw,     /* dew point temperature */
-               double *z,      /* elevation */
-               double *skvfac, /* sky view factor */
-               int nthreads,   /* number of threads for parrallel processing */
-               double *thermal /* thermal radiation (return) */
+void topotherm(
+    int ngrid,      /* number of grid points */
+    double *ta,     /* air temperature */
+    double *tw,     /* dew point temperature */
+    double *z,      /* elevation */
+    double *skvfac, /* sky view factor */
+    int nthreads,   /* number of threads for parrallel processing */
+    double *thermal /* thermal radiation (return) */
 ) {
-  int samp;
-  double ta_p, tw_p, z_p, skvfac_p; // pixel values
-  double ea;                        /*	vapor pressure */
-  double emiss;                     /*	atmos. emiss.  */
-  double T0;                        /*	Sea Level ta   */
-  double lw_in;                     /*	lw irradiance  */
-  double press;                     /*	air pressure   */
+    int samp;
+    double ta_p, tw_p, z_p, skvfac_p; // pixel values
+    double ea;                        /* vapor pressure */
+    double emiss;                     /* atmos. emiss.  */
+    double T0;                        /* Sea Level ta   */
+    double lw_in;                     /* lw irradiance  */
+    double press;                     /* air pressure   */
 
-  omp_set_dynamic(0); // Disable dynamic teams
-  omp_set_num_threads(nthreads);
+    omp_set_dynamic(0); // Disable dynamic teams
+    omp_set_num_threads(nthreads);
 
-#pragma omp parallel shared(ngrid, ta, tw, z, skvfac) private(                 \
-        samp, ta_p, tw_p, z_p, skvfac_p, ea, emiss, T0, press, lw_in)
-  {
+#pragma omp parallel shared(ngrid, ta, tw, z, skvfac) \
+    private(samp, ta_p, tw_p, z_p, skvfac_p, ea, emiss, T0, press, lw_in)
+    {
 #pragma omp for
-    for (samp = 0; samp < ngrid; samp++) {
+        for (samp = 0; samp < ngrid; samp++) {
 
-      ta_p = ta[samp];
-      tw_p = tw[samp];
-      z_p = z[samp];
-      skvfac_p = skvfac[samp];
+            ta_p     = ta[samp];
+            tw_p     = tw[samp];
+            z_p      = z[samp];
+            skvfac_p = skvfac[samp];
 
-      /* convert ta and tw from C to K */
-      ta_p += FREEZE;
-      tw_p += FREEZE;
+            /* convert ta and tw from C to K */
+            ta_p += FREEZE;
+            tw_p += FREEZE;
 
-      if (ta_p < 0 || tw_p < 0) {
-        printf("ta or tw < 0 at pixel %i", samp);
-        exit(-1);
-      }
+            if (ta_p < 0 || tw_p < 0) {
+                printf("ta or tw < 0 at pixel %i", samp);
+                exit(-1);
+            }
 
-      /* calculate theoretical sea level	*/
-      /* atmospheric emissivity  */
-      /* from reference level ta, tw, and z */
+            /* calculate theoretical sea level	*/
+            /* atmospheric emissivity  */
+            /* from reference level ta, tw, and z */
 
-      if (tw_p > ta_p) {
-        tw_p = ta_p;
-      }
+            if (tw_p > ta_p) {
+                tw_p = ta_p;
+            }
 
-      ea = saturation_vapor_pressure(&tw_p);
-      emiss = brutsaert(ta_p, STD_LAPSE_M, ea, z_p, SEA_LEVEL);
+            ea    = saturation_vapor_pressure(&tw_p);
+            emiss = brutsaert(ta_p, STD_LAPSE_M, ea, z_p, SEA_LEVEL);
 
-      /* calculate sea level air temp */
+            /* calculate sea level air temp */
 
-      T0 = ta_p - (z_p * STD_LAPSE_M);
+            T0 = ta_p - (z_p * STD_LAPSE_M);
 
-      /* adjust emiss for elev, terrain, veg, and cloud shading	*/
-      press = HYSTAT(SEA_LEVEL, T0, STD_LAPSE, (z_p / 1000.), GRAVITY, MOL_AIR);
+            /* adjust emiss for elev, terrain, veg, and cloud shading	*/
+            press = HYSTAT(SEA_LEVEL, T0, STD_LAPSE, (z_p / 1000.), GRAVITY, MOL_AIR);
 
-      /* elevation correction */
-      emiss *= press / SEA_LEVEL;
+            /* elevation correction */
+            emiss *= press / SEA_LEVEL;
 
-      /* terrain factor correction */
-      emiss = (emiss * skvfac_p) + (1.0 - skvfac_p);
+            /* terrain factor correction */
+            emiss = (emiss * skvfac_p) + (1.0 - skvfac_p);
 
-      /* check for emissivity > 1.0 */
-      if (emiss > 1.0)
-        emiss = 1.0;
+            /* check for emissivity > 1.0 */
+            if (emiss > 1.0)
+                emiss = 1.0;
 
-      /*	calculate incoming lw rad	*/
-      lw_in = emiss * STEF_BOLTZ * ta_p * ta_p * ta_p * ta_p;
+            /*	calculate incoming lw rad	*/
+            lw_in = emiss * STEF_BOLTZ * ta_p * ta_p * ta_p * ta_p;
 
-      /* set output band */
-      thermal[samp] = lw_in;
+            /* set output band */
+            thermal[samp] = lw_in;
+        }
     }
-  }
 }
 
 /*
@@ -97,21 +98,20 @@ void topotherm(int ngrid,      /* number of grid points */
  *      tk - air temperature (Kelvin)
  */
 double satw(double tk) {
-  double x;
-  errno = 0;
+    double x;
+    errno = 0;
 
-  x = -7.90298 * (BOIL / tk - 1.) + 5.02808 * log(BOIL / tk) / M_LN10 -
-      1.3816e-7 * (pow(1.e1, 1.1344e1 * (1. - tk / BOIL)) - 1.) +
-      8.1328e-3 * (pow(1.e1, -3.49149 * (BOIL / tk - 1.)) - 1.) +
-      log(SEA_LEVEL) / M_LN10;
+    x = -7.90298 * (BOIL / tk - 1.) + 5.02808 * log(BOIL / tk) / M_LN10
+        - 1.3816e-7 * (pow(1.e1, 1.1344e1 * (1. - tk / BOIL)) - 1.)
+        + 8.1328e-3 * (pow(1.e1, -3.49149 * (BOIL / tk - 1.)) - 1.) + log(SEA_LEVEL) / M_LN10;
 
-  x = pow(1.e1, x);
+    x = pow(1.e1, x);
 
-  if (errno) {
-    perror("satw: bad return from log or pow");
-  }
+    if (errno) {
+        perror("satw: bad return from log or pow");
+    }
 
-  return (x);
+    return (x);
 }
 
 /*
@@ -130,18 +130,20 @@ double satw(double tk) {
  *      tk - air temperature (Kelvin)
  */
 double sati(double tk) {
-  double x;
-  errno = 0;
+    double x;
+    errno = 0;
 
-  x = pow(1.e1, -9.09718 * ((FREEZE / tk) - 1.) -
-                    3.56654 * log(FREEZE / tk) / M_LN10 +
-                    8.76793e-1 * (1. - (tk / FREEZE)) + log(6.1071) / M_LN10);
+    x = pow(
+        1.e1,
+        -9.09718 * ((FREEZE / tk) - 1.) - 3.56654 * log(FREEZE / tk) / M_LN10
+            + 8.76793e-1 * (1. - (tk / FREEZE)) + log(6.1071) / M_LN10
+    );
 
-  if (errno) {
-    perror("sati: bad return from log or pow");
-  }
+    if (errno) {
+        perror("sati: bad return from log or pow");
+    }
 
-  return (x * 1.e2);
+    return (x * 1.e2);
 }
 
 /*
@@ -152,40 +154,41 @@ double sati(double tk) {
  *      temperature - air temperature (Kelvin)
  */
 double saturation_vapor_pressure(double *temperature) {
-  if (*temperature > FREEZE) {
-    return (satw(*temperature));
-  } else {
-    return (sati(*temperature));
-  }
+    if (*temperature > FREEZE) {
+        return (satw(*temperature));
+    } else {
+        return (sati(*temperature));
+    }
 }
 
 /*
  * calculates atmospheric emissivity using a modified form of the equations by
  * W. Brutsaert
  */
-double brutsaert(double ta,   /* air temp (K)				*/
-                 double lmba, /* temperature lapse rate (deg/m)	*/
-                 double ea,   /* vapor pressure (Pa)			*/
-                 double z,    /* elevation (z)			*/
-                 double pa)   /* air pressure (Pa)			*/
-{
-  double t_prime;
-  double rh;
-  double e_prime;
-  double air_emiss;
+double brutsaert(
+    double ta,   /* air temp (K) */
+    double lmba, /* temperature lapse rate (deg/m)	*/
+    double ea,   /* vapor pressure (Pa)	*/
+    double z,    /* elevation (z) */
+    double pa    /* air pressure (Pa) */
+) {
+    double t_prime;
+    double rh;
+    double e_prime;
+    double air_emiss;
 
-  t_prime = ta - (lmba * z);
-  rh = ea / saturation_vapor_pressure(&ta);
-  if (rh > 1.0) {
-    rh = 1.0;
-  }
-  e_prime = (rh * saturation_vapor_pressure(&t_prime)) / 100.0;
+    t_prime = ta - (lmba * z);
+    rh      = ea / saturation_vapor_pressure(&ta);
+    if (rh > 1.0) {
+        rh = 1.0;
+    }
+    e_prime = (rh * saturation_vapor_pressure(&t_prime)) / 100.0;
 
-  air_emiss = (1.24 * pow((e_prime / t_prime), 1. / 7.)) * pa / SEA_LEVEL;
-  /* "if" statement below is new */
-  if (air_emiss > 1.0) {
-    air_emiss = 1.0;
-  }
+    air_emiss = (1.24 * pow((e_prime / t_prime), 1. / 7.)) * pa / SEA_LEVEL;
+    /* "if" statement below is new */
+    if (air_emiss > 1.0) {
+        air_emiss = 1.0;
+    }
 
-  return (air_emiss);
+    return (air_emiss);
 }

--- a/smrf/envphys/core/topotherm.c
+++ b/smrf/envphys/core/topotherm.c
@@ -1,6 +1,3 @@
-/*
- * Saturation function over ice and water
- */
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/smrf/envphys/thermal/topotherm.py
+++ b/smrf/envphys/thermal/topotherm.py
@@ -1,8 +1,16 @@
 import numpy as np
 
-from smrf.envphys.constants import (FREEZE, GRAVITY, MOL_AIR, RGAS, SEA_LEVEL,
-                                    STD_LAPSE, STD_LAPSE_M, STEF_BOLTZ)
-from smrf.envphys.vapor_pressure import sati
+from smrf.envphys.constants import (
+    FREEZE,
+    GRAVITY,
+    MOL_AIR,
+    RGAS,
+    SEA_LEVEL,
+    STD_LAPSE,
+    STD_LAPSE_M,
+    STEF_BOLTZ,
+)
+from smrf.envphys.vapor_pressure import saturation_vapor_pressure
 
 
 def brutsaert(air_temp, lapse_rate, vapor_pressure, elevation, pressure):
@@ -23,13 +31,12 @@ def brutsaert(air_temp, lapse_rate, vapor_pressure, elevation, pressure):
     """
 
     t_prime = air_temp - (lapse_rate * elevation)
-    rh = vapor_pressure / sati(air_temp)
+    rh = vapor_pressure / saturation_vapor_pressure(air_temp)
     rh[rh > 1] = 1
 
-    e_prime = (rh * sati(t_prime)) / 100.0
+    e_prime = (rh * saturation_vapor_pressure(t_prime)) / 100.0
 
-    air_emiss = (1.24 * np.power(e_prime / t_prime, 1. / 7.0)) * \
-        pressure / SEA_LEVEL
+    air_emiss = (1.24 * np.power(e_prime / t_prime, 1.0 / 7.0)) * pressure / SEA_LEVEL
 
     air_emiss[air_emiss > 1.0] = 1.0
 
@@ -53,13 +60,13 @@ def hysat(pb, tb, L, h, g, m):
         hydrostatic results
 
     20151027 Scott Havens
-     """
+    """
 
     # the factors 1.e-3 and 1.e3 are for units conversion
     if L == 0:
-        return pb * np.exp(-g * m * h * 1.e3/(RGAS * tb))
+        return pb * np.exp(-g * m * h * 1.0e3 / (RGAS * tb))
     else:
-        return pb * np.power(tb/(tb + L * h), g * m/(RGAS * L * 1.e-3))
+        return pb * np.power(tb / (tb + L * h), g * m / (RGAS * L * 1.0e-3))
 
 
 def topotherm(ta, tw, z, skvfac):
@@ -95,7 +102,7 @@ def topotherm(ta, tw, z, skvfac):
     ind = tw > ta
     tw[ind] = ta[ind]
 
-    ea = sati(tw)
+    ea = saturation_vapor_pressure(tw)
     emiss = brutsaert(ta, STD_LAPSE_M, ea, z, SEA_LEVEL)
 
     # calculate sea level air temp
@@ -103,10 +110,10 @@ def topotherm(ta, tw, z, skvfac):
 
     # adjust emiss for elev, terrain
     # veg, and cloud shading
-    press = hysat(SEA_LEVEL, T0, STD_LAPSE, z/1000.0, GRAVITY, MOL_AIR)
+    press = hysat(SEA_LEVEL, T0, STD_LAPSE, z / 1000.0, GRAVITY, MOL_AIR)
 
     # elevation correction
-    emiss *= press/SEA_LEVEL
+    emiss *= press / SEA_LEVEL
 
     # terrain factor correction
     emiss = (emiss * skvfac) + (1.0 - skvfac)

--- a/smrf/envphys/vapor_pressure.py
+++ b/smrf/envphys/vapor_pressure.py
@@ -14,7 +14,7 @@ def saturation_vapor_pressure(air_temperature: npt.NDArray) -> npt.NDArray:
         air_temperature: temperature in Kelvin
 
     Returns:
-        Saturated vapor pressure over water
+        Saturated vapor pressure
     """
     temperature_k = np.ascontiguousarray(air_temperature, dtype=np.float64)
     output = np.zeros_like(temperature_k)

--- a/smrf/envphys/vapor_pressure.py
+++ b/smrf/envphys/vapor_pressure.py
@@ -1,68 +1,27 @@
 import numpy as np
+import numpy.typing as npt
 
-from smrf.envphys.constants import BOIL, FREEZE, SEA_LEVEL
+from smrf.envphys.core import envphys_c
 
 
-def satw(tk):
+def saturation_vapor_pressure(air_temperature: npt.NDArray) -> npt.NDArray:
     """
-    Saturation vapor pressure of water. from IPW satw
+    Saturation vapor pressure using Goff-Gratch formulations for given temperatures.
+
+    See the C functions `sati` and `satw` in topotherm.c for more references.
 
     Args:
-        tk: temperature in Kelvin
+        air_temperature: temperature in Kelvin
 
     Returns:
-        saturated vapor pressure over water
-
-    20151027 Scott Havens
+        Saturated vapor pressure over water
     """
+    temperature_k = np.ascontiguousarray(air_temperature, dtype=np.float64)
+    output = np.zeros_like(temperature_k)
 
-    # remove bad values
-    tk[tk < 0] = np.nan
+    envphys_c.svp_for_temperatures(temperature_k, output)
 
-    l10 = np.log(10.0)
-
-    btk = BOIL/tk
-    x = -7.90298*(btk - 1.0) + 5.02808*np.log(btk)/l10 - \
-        1.3816e-7*(np.power(10.0, 1.1344e1*(1.0 - tk/BOIL))-1.) + \
-        8.1328e-3*(np.power(10.0, -3.49149*(btk - 1.0)) - 1.0) + \
-        np.log(SEA_LEVEL)/l10
-
-    x = np.power(10.0, x)
-
-    return x
-
-
-def sati(tk):
-    """
-    saturation vapor pressure over ice. From IPW sati
-
-    Args:
-        tk: temperature in Kelvin
-
-    Returns:
-        saturated vapor pressure over ice
-
-    20151027 Scott Havens
-    """
-
-    # remove bad values
-    tk[tk < 0] = np.nan
-
-    # preallocate
-    x = np.empty(tk.shape)
-
-    # vapor above freezing
-    ind = tk > FREEZE
-    x[ind] = satw(tk[ind])
-
-    # vapor below freezing
-    l10 = np.log(10.0)
-    x[~ind] = 100.0 * np.power(10.0, -9.09718*((FREEZE/tk[~ind]) - 1.0) -
-                               3.56654*np.log(FREEZE/tk[~ind])/l10 +
-                               8.76793e-1*(1.0 - (tk[~ind]/FREEZE)) +
-                               np.log(6.1071)/l10)
-
-    return x
+    return output
 
 
 def idewpt(vp):
@@ -82,18 +41,17 @@ def idewpt(vp):
     vp = np.array(vp)
 
     # take the log and convert to kPa
-    vp = np.log(vp/float(1000))
+    vp = np.log(vp / float(1000))
 
     # calculate the vapor pressure
-    Td = (vp + 0.4926) / (0.0708 - 0.00421*vp)
+    Td = (vp + 0.4926) / (0.0708 - 0.00421 * vp)
 
     return Td
 
 
-def rh2vp(ta, rh):
+def rh2vp(ta: npt.NDArray, rh: npt.NDArray) -> npt.NDArray:
     """
-    Calculate the vapor pressure given the air temperature
-    and relative humidity
+    Calculate the vapor pressure given the air temperature and relative humidity
 
     Args:
         ta: array of air temperature in [C]
@@ -104,23 +62,22 @@ def rh2vp(ta, rh):
     """
 
     if rh.flat[0] >= 1.0:
-        rh = rh/100.0
+        rh = rh / 100.0
 
-    satvp = sati(ta + 273.15)
+    satvp = saturation_vapor_pressure(ta + 273.15)
 
     return satvp * rh
 
 
-def satvp(dpt):
+def satvp(dpt: npt.NDArray) -> npt.NDArray:
     """
-    Calculate the saturation vapor pressure at the dew point
-    temperature.
+    Calculate the saturation vapor pressure at the dew point temperature.
 
     Args:
-        dwpt: array of dew point temperature in [C]
+        dpt: array of dew point temperature in [C]
 
-    Returns
-       vapor_pressure
+    Returns:
+        vapor_pressure
     """
 
-    return sati(dpt + 273.15)
+    return saturation_vapor_pressure(dpt + 273.15)

--- a/smrf/envphys/vapor_pressure.py
+++ b/smrf/envphys/vapor_pressure.py
@@ -69,15 +69,15 @@ def rh2vp(ta: npt.NDArray, rh: npt.NDArray) -> npt.NDArray:
     return satvp * rh
 
 
-def satvp(dpt: npt.NDArray) -> npt.NDArray:
+def svp_for_celsius(t_in_c: npt.NDArray) -> npt.NDArray:
     """
-    Calculate the saturation vapor pressure at the dew point temperature.
+    Calculate the saturation vapor pressure for temperatures in Celsius
 
     Args:
-        dpt: array of dew point temperature in [C]
+        t_in_c: array of temperatures in [C]
 
     Returns:
         vapor_pressure
     """
 
-    return saturation_vapor_pressure(dpt + 273.15)
+    return saturation_vapor_pressure(t_in_c + 273.15)

--- a/smrf/tests/distribute/__init__.py
+++ b/smrf/tests/distribute/__init__.py
@@ -5,13 +5,16 @@ import numpy as np
 from smrf.data import Topo
 
 SKY_VIEW_FACTOR_MOCK = np.array([[1.0, 1.0]])
-TOPO_MOCK = MagicMock(
-    spec=Topo,
-    dem=np.array([[200.0, 150.0], [300.0, 225.0]]),
-    sky_view_factor=SKY_VIEW_FACTOR_MOCK,
-    veg_height=np.array([[5.0, 10.0]]),
-    veg_type=np.array([[1.0, 1.0], [1.0, 1.0]]),
-    veg_k=np.array([[0.8, 0.1]]),
-    veg_tau=np.array([[0.6, 0.7]]),
-    instance=True,
-)
+
+
+def topo_mock():
+    return MagicMock(
+        spec=Topo,
+        dem=np.array([[200.0, 150.0], [300.0, 225.0]]),
+        sky_view_factor=SKY_VIEW_FACTOR_MOCK,
+        veg_height=np.array([[5.0, 10.0]]),
+        veg_type=np.array([[1.0, 1.0], [1.0, 1.0]]),
+        veg_k=np.array([[0.8, 0.1]]),
+        veg_tau=np.array([[0.6, 0.7]]),
+        instance=True,
+    )

--- a/smrf/tests/distribute/test_albedo.py
+++ b/smrf/tests/distribute/test_albedo.py
@@ -7,8 +7,8 @@ import pandas as pd
 import pytz
 
 from smrf.distribute.albedo import Albedo
+from smrf.tests.distribute import topo_mock
 from smrf.tests.smrf_config import SMRFConfig
-from smrf.tests.distribute import TOPO_MOCK
 
 CONFIG = {
     "time": {
@@ -45,11 +45,11 @@ ALBEDO_IR = np.array([[0.8, 1.0], [1.0, 0.9]])
 
 class TestAlbedo(SMRFConfig, unittest.TestCase):
     def setUp(self):
-        self.subject = Albedo(CONFIG, TOPO_MOCK)
+        self.subject = Albedo(CONFIG, topo_mock())
         self.subject.initialize(DATA)
 
     def test_init_default(self):
-        subject = Albedo(CONFIG, TOPO_MOCK)
+        subject = Albedo(CONFIG, topo_mock())
 
         self.assertIsNone(subject.albedo)
         self.assertIsNone(subject.albedo_vis)
@@ -90,7 +90,7 @@ class TestAlbedo(SMRFConfig, unittest.TestCase):
 
         config = self._copy_config(CONFIG)
         config["albedo"]["source_files"] = "path/to/files"
-        subject = Albedo(config, TOPO_MOCK)
+        subject = Albedo(config, topo_mock())
         subject.initialize(pd.DataFrame())
 
         subject.distribute(TIMESTEP, COS_Z, STORM_DAYS)
@@ -109,7 +109,7 @@ class TestAlbedo(SMRFConfig, unittest.TestCase):
 
         config = self._copy_config(CONFIG)
         config["albedo"]["source_files"] = "path/to/files"
-        subject = Albedo(config, TOPO_MOCK)
+        subject = Albedo(config, topo_mock())
         subject.initialize(pd.DataFrame())
 
         subject.distribute(TIMESTEP, COS_Z, STORM_DAYS)
@@ -133,7 +133,7 @@ class TestAlbedo(SMRFConfig, unittest.TestCase):
 
         config = self._copy_config(CONFIG)
         config["albedo"]["source_files"] = "path/to/files"
-        subject = Albedo(config, TOPO_MOCK)
+        subject = Albedo(config, topo_mock())
         subject.initialize(pd.DataFrame())
 
         subject.distribute(TIMESTEP, COS_Z, STORM_DAYS)
@@ -206,7 +206,7 @@ class TestAlbedo(SMRFConfig, unittest.TestCase):
         args, _ = mock_decay_power.call_args
 
         npt.assert_array_equal(args[0], self.subject.veg)
-        npt.assert_array_equal(args[1], TOPO_MOCK.veg_type)
+        npt.assert_array_equal(args[1], topo_mock().veg_type)
         self.assertEqual(args[2], current_hours)
         self.assertEqual(args[3], decay_hours)
         npt.assert_array_equal(args[4], self.subject.config["date_method_decay_power"])
@@ -225,9 +225,7 @@ class TestAlbedo(SMRFConfig, unittest.TestCase):
 
         mock_decay_power.return_value = MagicMock(), MagicMock()
 
-        self.subject.date_method(
-            ALBEDO_VIS, ALBEDO_IR, 1, 2, STORM_DAYS
-        )
+        self.subject.date_method(ALBEDO_VIS, ALBEDO_IR, 1, 2, STORM_DAYS)
         mock_decay_power.assert_called_once()
 
     @patch("smrf.envphys.albedo.decay_burned")
@@ -271,8 +269,6 @@ class TestAlbedo(SMRFConfig, unittest.TestCase):
         self.subject.config["post_fire_k_burned"] = None
 
         with self.assertRaises(ValueError) as context:
-            self.subject.date_method(
-                ALBEDO_VIS, ALBEDO_IR, 1, 1, STORM_DAYS
-            )
+            self.subject.date_method(ALBEDO_VIS, ALBEDO_IR, 1, 1, STORM_DAYS)
 
         self.assertIn("post_fire_k_burned is not set", str(context.exception))

--- a/smrf/tests/distribute/test_solar.py
+++ b/smrf/tests/distribute/test_solar.py
@@ -4,11 +4,8 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pandas as pd
 
-from smrf.data import Topo
 from smrf.distribute import Solar
-
-SKY_VIEW_FACTOR_MOCK = np.ones((1, 2, 4))
-TOPO_MOCK = MagicMock(spec=Topo, sky_view_factor=SKY_VIEW_FACTOR_MOCK, instance=True)
+from smrf.tests.distribute import topo_mock
 
 DATETIME = pd.to_datetime("2025-11-01 00:00:00")
 COS_Z = np.cos(np.radians(10))
@@ -39,7 +36,7 @@ class TestSolar(unittest.TestCase):
                     "time_zone": "utc",
                 },
             },
-            topo=TOPO_MOCK,
+            topo=topo_mock(),
         )
 
     def test_initialize(self):

--- a/smrf/tests/distribute/test_solar_hrrr.py
+++ b/smrf/tests/distribute/test_solar_hrrr.py
@@ -6,7 +6,7 @@ import numpy.testing as npt
 import pandas as pd
 
 from smrf.distribute import Albedo, SolarHRRR
-from smrf.tests.distribute import SKY_VIEW_FACTOR_MOCK, TOPO_MOCK
+from smrf.tests.distribute import SKY_VIEW_FACTOR_MOCK, topo_mock
 
 DATETIME = pd.to_datetime("2025-11-01 00:00:00")
 DATA_MOCK = {
@@ -37,9 +37,9 @@ class TestSolarHRRR(unittest.TestCase):
         }
         self.subject = SolarHRRR(
             config=config,
-            topo=TOPO_MOCK,
+            topo=topo_mock(),
         )
-        self.albedo = Albedo(config=config, topo=TOPO_MOCK)
+        self.albedo = Albedo(config=config, topo=topo_mock())
         self.albedo.albedo_vis = ALBEDO_1
         self.albedo.albedo_ir = ALBEDO_2
 
@@ -57,7 +57,9 @@ class TestSolarHRRR(unittest.TestCase):
             self.albedo,
         )
 
-        shade_mock.assert_called_once_with(COS_Z, AZIMUTH, ILLUMINATION_MOCK, TOPO_MOCK)
+        shade_mock.assert_called_once_with(
+            COS_Z, AZIMUTH, ILLUMINATION_MOCK, self.subject.topo
+        )
 
         ghi_vis = DATA_MOCK[SolarHRRR.VBDSF] * COS_Z + DATA_MOCK[SolarHRRR.VDDSF]
         npt.assert_equal(ghi_vis, self.subject.solar_ghi_vis)

--- a/smrf/tests/distribute/test_thermal_hrrr.py
+++ b/smrf/tests/distribute/test_thermal_hrrr.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 from smrf.distribute import ThermalHRRR
 from smrf.envphys.constants import EMISS_TERRAIN, FREEZE, STEF_BOLTZ
-from smrf.tests.distribute import SKY_VIEW_FACTOR_MOCK, TOPO_MOCK
+from smrf.tests.distribute import SKY_VIEW_FACTOR_MOCK, topo_mock
 from smrf.tests.smrf_config import SMRFConfig
 
 RAW_DATA_MOCK = np.ones((1, 1))
@@ -28,7 +28,7 @@ CONFIG = {
 
 class TestThermalHRRR(unittest.TestCase, SMRFConfig):
     def test_distribute(self):
-        self.subject = ThermalHRRR(config=CONFIG, topo=TOPO_MOCK)
+        self.subject = ThermalHRRR(config=CONFIG, topo=topo_mock())
 
         result = (SKY_VIEW_FACTOR_MOCK * RAW_DATA_MOCK) + (
             1 - SKY_VIEW_FACTOR_MOCK
@@ -43,7 +43,7 @@ class TestThermalHRRR(unittest.TestCase, SMRFConfig):
     def test_distribute_vegetation(self, mock_vegetation):
         config = self._copy_config(CONFIG)
         config["thermal"]["correct_veg"] = True
-        self.subject = ThermalHRRR(config=config, topo=TOPO_MOCK)
+        self.subject = ThermalHRRR(config=config, topo=topo_mock())
 
         self.subject.initialize(pd.DataFrame())
         self.subject.distribute("2025-09-20=9", RAW_DATA_MOCK, AIR_TEMP_MOCK)

--- a/smrf/tests/distribute/test_vapor_pressure.py
+++ b/smrf/tests/distribute/test_vapor_pressure.py
@@ -1,0 +1,55 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import numpy.testing as npt
+
+from smrf.distribute import VaporPressure
+from smrf.tests.distribute import topo_mock
+
+RAW_DATA_MOCK = np.ones((1, 1))
+# Temperatures in C: 25, nan, 0, -10
+TEMPERATURES = np.array(
+    [[298.15, 274.15], [273.15, 263.15]], dtype=np.float64, order="C"
+)
+
+DATA_MOCK = MagicMock(thermal=RAW_DATA_MOCK)
+
+CONFIG = {
+    "time": {
+        "start_date": "2025-09-20 00:00",
+        "time_zone": "utc",
+    },
+    "vapor_pressure": {
+        "dew_point_tolerance": 0.01,
+        "threads": 1,
+    },
+    "precip": {
+        "precip_temp_method": "wet_bulb",
+    },
+}
+
+
+class TestVaporPressure(unittest.TestCase):
+    def setUp(self):
+        self.subject = VaporPressure(config=CONFIG, topo=topo_mock())
+
+    @patch("smrf.distribute.VaporPressure._distribute")
+    def test_wet_bulb_temperature(self, mock_distribute):
+        self.subject.vapor_pressure = np.array(
+            [[3167.9, 657.1], [611.3, 259.7]], dtype=np.float64, order="C"
+        )
+
+        self.subject.distribute(DATA_MOCK, TEMPERATURES)
+        mock_distribute.assert_called_once()
+
+        expected_vp = np.array(
+            [[61.993499, 57.021897], [56.526332, 55.035582]],
+            dtype=np.float64,
+            order="C",
+        )
+        npt.assert_array_almost_equal(
+            expected_vp,
+            self.subject.precip_temp,
+            decimal=2,
+        )

--- a/smrf/tests/envphys/test_vapor_pressure.py
+++ b/smrf/tests/envphys/test_vapor_pressure.py
@@ -12,4 +12,4 @@ class TestVaporPressure(unittest.TestCase):
         temperatures = np.array([[298.15, -1], [273.15, 263.15]])
         expected_pressures = np.array([[3166.703565, np.nan], [610.207270, 259.471371]])
 
-        npt.assert_allclose(saturation_vapor_pressure(temperatures), expected_pressures)
+        npt.assert_allclose(saturation_vapor_pressure(temperatures), expected_pressures, equal_nan=True)

--- a/smrf/tests/envphys/test_vapor_pressure.py
+++ b/smrf/tests/envphys/test_vapor_pressure.py
@@ -1,0 +1,15 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+from smrf.envphys.vapor_pressure import saturation_vapor_pressure
+
+
+class TestVaporPressure(unittest.TestCase):
+    def test_vapor_pressure(self):
+        # Temperatures in C: 25, nan, 0, -10
+        temperatures = np.array([[298.15, -1], [273.15, 263.15]])
+        expected_pressures = np.array([[3166.703565, np.nan], [610.207270, 259.471371]])
+
+        npt.assert_allclose(saturation_vapor_pressure(temperatures), expected_pressures)


### PR DESCRIPTION
Introduction of a unified `saturation_vapor_pressure` function, which replaces direct calls to `satw` and `sati` with a single interface in both C and Python code. Additionally, several unused or redundant constants and macros are removed from `envphys.h`, and the code style is cleaned up for consistency.

The most important changes are:

**Saturation Vapor Pressure Refactor:**
* Introduced a new `saturation_vapor_pressure(double *temperature)` function in C (`topotherm.c`/`envphys_c.h`) that selects the appropriate formula (over ice or water) based on temperature, replacing direct calls to `satw` and `sati` throughout the codebase.
* Updated the Python interface and added a Cython wrapper `svp_for_temperatures` to efficiently apply the new saturation vapor pressure function to arrays.

**Code Cleanup:**
* Removed unused or redundant constants and macros from `envphys.h`
* Improved code style and header usage in C files for consistency and clarity.
* Added a "clang-format" to consistently format C code between pysnobal and SMRF

# NOTE
This could also be a first template on how to approach the `tk less than zero` error in pysnobal, by making less of a wild goose chase where and how `sati` is called. Ideally we would not have the copied code from IPW in SMRF, but then you wouldn't be able to install SMRF without pysnobal. The latter is something I would happily introduce as a dependency with SMRF since pysnobal is a quick and lightweight install. Thoughts?